### PR TITLE
Implement exponential-space einsum

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "ebe7aa44-baf0-506c-a96f-8464559b3922"
 authors = ["Andreas Peter <andreas.peter.ch@gmail.com>"]
 version = "0.1.0"
 
+[deps]
+TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/OMEinsum.jl
+++ b/src/OMEinsum.jl
@@ -1,9 +1,66 @@
 module OMEinsum
+export einsum
+
+function einsum(cs, ts)
+    allins  = reduce(vcat, collect.(cs))
+    outinds = sort(filter(x -> count(==(x), allins) == 1, allins))
+    einsum(cs, ts, outinds)
+end
 
 @doc raw"
-   greet()
-say hello to the world!
+    einsum(cs, ts, out)
+return the tensor that results from contracting the tensors `ts` according
+to their indices `cs`, where twice-appearing indices are contracted.
+The result is permuted according to `out`.
+
+- `cs` - tuple of tuple of integers that label all indices of a tensor.
+       Indices that appear twice (in different tensors) are summed over
+
+- `ts` - tuple of tensors
+
+- `out` - tuple of integers that should correspond to remaining indices in `cs` after contractions.
+
+This implementation has space requirements that are exponential in the number of unique indices.
+
+# example
+```jldoctest; setup = :(using OMEinsum)
+julia> a = rand(2,2);
+
+julia> b = rand(2,2);
+
+julia> einsum(((1,2),(2,3)), (a, b), (1,3)) ≈ a * b
+true
+
+julia> einsum(((1,2),(2,3)), (a, b), (3,1)) ≈ permutedims(a * b, (2,1))
+true
+```
 "
-greet() = print("Hello World!")
+function einsum(contractions, tensors, outinds)
+    T = mapreduce(eltype, promote_type, tensors)
+    l = length(tensors)
+    allins = reduce(vcat, collect.(contractions))
+    uniqueallins = unique(allins)
+    ntensors = permuteandreshape.(Ref(uniqueallins), tensors, contractions)
+
+    ds = unique([i for i in allins if count(==(i), allins) > 1])
+    ds = map(i -> findfirst(==(i), uniqueallins), ds)
+
+    t = sum(broadcast(*, ntensors...), dims=ds)
+    tf = dropdims(t, dims = tuple(ds...))
+    x = [i for i in uniqueallins if i in outinds]
+    p = map(i -> findfirst(==(i),x), outinds)
+    tff = permutedims(tf,p)
+end
+
+function permuteandreshape(uniqueallins, t, c)
+    x = [i for i in uniqueallins if i in c]
+    p = map(i -> findfirst(==(i),x), c)
+    rs = map(uniqueallins) do i
+            j = findfirst(==(i), c)
+            isnothing(j) && return 1
+            return size(t,j)
+        end
+    return reshape(permutedims(t,p),rs...)
+end
 
 end # module

--- a/src/OMEinsum.jl
+++ b/src/OMEinsum.jl
@@ -47,9 +47,10 @@ function einsum(contractions, tensors, outinds)
 
     t = sum(broadcast(*, ntensors...), dims=ds)
     tf = dropdims(t, dims = tuple(ds...))
+    isempty(outinds) && return tf
     x = [i for i in uniqueallins if i in outinds]
     p = map(i -> findfirst(==(i),x), outinds)
-    tff = permutedims(tf,p)
+    return permutedims(tf,p)
 end
 
 function permuteandreshape(uniqueallins, t, c)

--- a/src/OMEinsum.jl
+++ b/src/OMEinsum.jl
@@ -1,67 +1,8 @@
 module OMEinsum
 export einsum
 
-function einsum(cs, ts)
-    allins  = reduce(vcat, collect.(cs))
-    outinds = sort(filter(x -> count(==(x), allins) == 1, allins))
-    einsum(cs, ts, outinds)
-end
 
-@doc raw"
-    einsum(cs, ts, out)
-return the tensor that results from contracting the tensors `ts` according
-to their indices `cs`, where twice-appearing indices are contracted.
-The result is permuted according to `out`.
 
-- `cs` - tuple of tuple of integers that label all indices of a tensor.
-       Indices that appear twice (in different tensors) are summed over
-
-- `ts` - tuple of tensors
-
-- `out` - tuple of integers that should correspond to remaining indices in `cs` after contractions.
-
-This implementation has space requirements that are exponential in the number of unique indices.
-
-# example
-```jldoctest; setup = :(using OMEinsum)
-julia> a = rand(2,2);
-
-julia> b = rand(2,2);
-
-julia> einsum(((1,2),(2,3)), (a, b), (1,3)) ≈ a * b
-true
-
-julia> einsum(((1,2),(2,3)), (a, b), (3,1)) ≈ permutedims(a * b, (2,1))
-true
-```
-"
-function einsum(contractions, tensors, outinds)
-    T = mapreduce(eltype, promote_type, tensors)
-    l = length(tensors)
-    allins = reduce(vcat, collect.(contractions))
-    uniqueallins = unique(allins)
-    ntensors = permuteandreshape.(Ref(uniqueallins), tensors, contractions)
-
-    ds = unique([i for i in setdiff(allins, outinds)])
-    ds = map(i -> findfirst(==(i), uniqueallins), ds)
-
-    t = sum(broadcast(*, ntensors...), dims=ds)
-    tf = dropdims(t, dims = tuple(ds...))
-    isempty(outinds) && return tf
-    x = [i for i in uniqueallins if i in outinds]
-    p = map(i -> findfirst(==(i),x), outinds)
-    return permutedims(tf,p)
-end
-
-function permuteandreshape(uniqueallins, t, c)
-    x = [i for i in uniqueallins if i in c]
-    p = map(i -> findfirst(==(i),x), c)
-    rs = map(uniqueallins) do i
-            j = findfirst(==(i), c)
-            j === nothing && return 1
-            return size(t,j)
-        end
-    return reshape(permutedims(t,p),rs...)
-end
+include("einsum.jl")
 
 end # module

--- a/src/OMEinsum.jl
+++ b/src/OMEinsum.jl
@@ -57,7 +57,7 @@ function permuteandreshape(uniqueallins, t, c)
     p = map(i -> findfirst(==(i),x), c)
     rs = map(uniqueallins) do i
             j = findfirst(==(i), c)
-            isnothing(j) && return 1
+            j === nothing && return 1
             return size(t,j)
         end
     return reshape(permutedims(t,p),rs...)

--- a/src/OMEinsum.jl
+++ b/src/OMEinsum.jl
@@ -42,7 +42,7 @@ function einsum(contractions, tensors, outinds)
     uniqueallins = unique(allins)
     ntensors = permuteandreshape.(Ref(uniqueallins), tensors, contractions)
 
-    ds = unique([i for i in allins if count(==(i), allins) > 1])
+    ds = unique([i for i in setdiff(allins, outinds)])
     ds = map(i -> findfirst(==(i), uniqueallins), ds)
 
     t = sum(broadcast(*, ntensors...), dims=ds)

--- a/src/OMEinsum.jl
+++ b/src/OMEinsum.jl
@@ -1,6 +1,7 @@
 module OMEinsum
 export einsum
 
+using TupleTools
 
 
 include("einsum.jl")

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -1,7 +1,7 @@
 function einsum(cs, ts)
     allins  = reduce(vcat, collect.(cs))
     outinds = sort(filter(x -> count(==(x), allins) == 1, allins))
-    einsum(cs, ts, outinds)
+    einsum(cs, ts, tuple(outinds...))
 end
 
 @doc raw"
@@ -32,7 +32,9 @@ julia> einsum(((1,2),(2,3)), (a, b), (3,1)) ≈ permutedims(a * b, (2,1))
 true
 ```
 "
-function einsum(contractions, tensors, outinds)
+function einsum(contractions::NTuple{N, NTuple{M, Int} where M},
+                tensors::NTuple{N, Array{<:Any,M} where M},
+                outinds::NTuple{<:Any,Int}) where N
     T = mapreduce(eltype, promote_type, tensors)
     sizes = reduce(TupleTools.vcat,size.(tensors))
     indices = reduce(TupleTools.vcat, contractions)
@@ -43,8 +45,10 @@ function einsum(contractions, tensors, outinds)
 end
 
 
-function einsum!(contractions, tensors, outinds, out)
-    l = length(tensors)
+function einsum!(contractions::NTuple{N, NTuple{M, Int} where M},
+                tensors::NTuple{N, Array{<:Any,M} where M},
+                outinds::NTuple{L,Int},
+                out::Array{<:Any,L}) where {N,L}
     allins = reduce(vcat, collect.(contractions))
     uniqueallins = unique(allins)
     ntensors = permuteandreshape.(Ref(uniqueallins), tensors, contractions)

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -1,0 +1,62 @@
+function einsum(cs, ts)
+    allins  = reduce(vcat, collect.(cs))
+    outinds = sort(filter(x -> count(==(x), allins) == 1, allins))
+    einsum(cs, ts, outinds)
+end
+
+@doc raw"
+    einsum(cs, ts, out)
+return the tensor that results from contracting the tensors `ts` according
+to their indices `cs`, where twice-appearing indices are contracted.
+The result is permuted according to `out`.
+
+- `cs` - tuple of tuple of integers that label all indices of a tensor.
+       Indices that appear twice (in different tensors) are summed over
+
+- `ts` - tuple of tensors
+
+- `out` - tuple of integers that should correspond to remaining indices in `cs` after contractions.
+
+This implementation has space requirements that are exponential in the number of unique indices.
+
+# example
+```jldoctest; setup = :(using OMEinsum)
+julia> a = rand(2,2);
+
+julia> b = rand(2,2);
+
+julia> einsum(((1,2),(2,3)), (a, b), (1,3)) ≈ a * b
+true
+
+julia> einsum(((1,2),(2,3)), (a, b), (3,1)) ≈ permutedims(a * b, (2,1))
+true
+```
+"
+function einsum(contractions, tensors, outinds)
+    T = mapreduce(eltype, promote_type, tensors)
+    l = length(tensors)
+    allins = reduce(vcat, collect.(contractions))
+    uniqueallins = unique(allins)
+    ntensors = permuteandreshape.(Ref(uniqueallins), tensors, contractions)
+
+    ds = unique([i for i in setdiff(allins, outinds)])
+    ds = map(i -> findfirst(==(i), uniqueallins), ds)
+
+    t = sum(broadcast(*, ntensors...), dims=ds)
+    tf = dropdims(t, dims = tuple(ds...))
+    isempty(outinds) && return tf
+    x = [i for i in uniqueallins if i in outinds]
+    p = map(i -> findfirst(==(i),x), outinds)
+    return permutedims(tf,p)
+end
+
+function permuteandreshape(uniqueallins, t, c)
+    x = [i for i in uniqueallins if i in c]
+    p = map(i -> findfirst(==(i),x), c)
+    rs = map(uniqueallins) do i
+            j = findfirst(==(i), c)
+            j === nothing && return 1
+            return size(t,j)
+        end
+    return reshape(permutedims(t,p),rs...)
+end

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -34,6 +34,16 @@ true
 "
 function einsum(contractions, tensors, outinds)
     T = mapreduce(eltype, promote_type, tensors)
+    sizes = reduce(TupleTools.vcat,size.(tensors))
+    indices = reduce(TupleTools.vcat, contractions)
+    outdims = map(x -> sizes[findfirst(==(x), indices)], outinds)
+    out = Array{T}(undef,outdims...)
+
+    einsum!(contractions, tensors, outinds, out)
+end
+
+
+function einsum!(contractions, tensors, outinds, out)
     l = length(tensors)
     allins = reduce(vcat, collect.(contractions))
     uniqueallins = unique(allins)
@@ -47,7 +57,7 @@ function einsum(contractions, tensors, outinds)
     isempty(outinds) && return tf
     x = [i for i in uniqueallins if i in outinds]
     p = map(i -> findfirst(==(i),x), outinds)
-    return permutedims(tf,p)
+    return permutedims!(out, tf, p)
 end
 
 function permuteandreshape(uniqueallins, t, c)

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -42,6 +42,7 @@ function einsum(contractions::NTuple{N, NTuple{M, Int} where M},
     out = Array{T}(undef,outdims...)
 
     einsum!(contractions, tensors, outinds, out)
+    return out
 end
 
 
@@ -58,10 +59,14 @@ function einsum!(contractions::NTuple{N, NTuple{M, Int} where M},
 
     t = sum(broadcast(*, ntensors...), dims=ds)
     tf = dropdims(t, dims = tuple(ds...))
-    isempty(outinds) && return tf
-    x = [i for i in uniqueallins if i in outinds]
-    p = map(i -> findfirst(==(i),x), outinds)
-    return permutedims!(out, tf, p)
+    if isempty(outinds)
+        copyto!(out, tf)
+    else
+        x = [i for i in uniqueallins if i in outinds]
+        p = map(i -> findfirst(==(i),x), outinds)
+        permutedims!(out, tf, p)
+    end
+    return out
 end
 
 function permuteandreshape(uniqueallins, t, c)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,4 +30,9 @@ using Test
         aaa[j,k,l] += a[i,j] * a[i,k] * a[i,l]
     end
     @test aaa ≈ einsum(((1,2),(1,3),(1,4)), (a,a,a))
+
+    let p = (2,3,1,4)
+        @test einsum(((1,2,3,4),), (t,),p) ≈ permutedims(t,p)
+    end
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,31 @@ using Test
 
 @testset "OMEinsum.jl" begin
     # Write your own tests here.
+    a,b,c = randn(2,2), rand(2,2), rand(2,2)
+    v = rand(2)
+    t = randn(2,2,2,2)
+    @test einsum(((1,2),(2,3),(3,4)), (a,b,c)) ≈ a * b * c
+    @test einsum(((1,20),(20,3),(3,4)), (a,b,c)) ≈ a * b * c
+    @test einsum(((1,2),(2,3),(3,4)), (a,b,c), (4,1)) ≈ permutedims(a*b*c, (2,1))
+    @test einsum(((1,2),(2,)), (a,v)) ≈ a * v
+
+    @test_broken einsum(((1,1),), (a,))
+    @test einsum(((1,2),), (a,), (2,1)) ≈ permutedims(a,(2,1))
+    ta = zeros(size(t)[[1,2]]...)
+    for (i,j,k,l) in Iterators.product(1:2,1:2,1:2,1:2)
+        ta[i,l] += t[i,j,k,l] * a[j,k]
+    end
+    @test einsum(((1,2,3,4), (2,3)), (t,a)) ≈  ta
+
+    ta = zeros(size(t)[[1,2]]...)
+    for (i,j,k,l) in Iterators.product(1:2,1:2,1:2,1:2)
+        ta[i,l] += t[l,k,j,i] * a[j,k]
+    end
+    @test einsum(((4,3,2,1), (2,3)), (t,a),(1,4)) ≈  ta
+
+    aaa = zeros(2,2,2);
+    for (i,j,k,l) in Iterators.product(1:2,1:2,1:2,1:2)
+        aaa[j,k,l] += a[i,j] * a[i,k] * a[i,l]
+    end
+    @test aaa ≈ einsum(((1,2),(1,3),(1,4)), (a,a,a))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,9 @@ using OMEinsum
 using Test
 
 @testset "OMEinsum.jl" begin
-    # Write your own tests here.
+
+
+    # matrix and vector multiplication
     a,b,c = randn(2,2), rand(2,2), rand(2,2)
     v = rand(2)
     t = randn(2,2,2,2)
@@ -11,8 +13,26 @@ using Test
     @test einsum(((1,2),(2,3),(3,4)), (a,b,c), (4,1)) ≈ permutedims(a*b*c, (2,1))
     @test einsum(((1,2),(2,)), (a,v)) ≈ a * v
 
-    @test_broken einsum(((1,1),), (a,))
+    # contract to 0-dim array
+    @test einsum(((1,2),(1,2)), (a,a), ()) ≈ [sum(a .* a)]
+
+    # trace
+    @test_broken einsum(((1,1),), (a,)) ≈ sum(a[i,i] for i in 1:2)
+    aa = rand(2,4,4,2)
+    @test_broken einsum(((1,2,2,1),), (aa,)) ≈ sum(a[i,j,j,i] for i in 1:2, j in 1:2)
+
+    # partial trace
+    @test_broken einsum((1,2,2,3), (aa,)) ≈ sum(aa[:,i,i,:] for i in 1:4)
+
+    # diag
+    @test_broken einsum((1,2,2,3), (aa,), (1,2,3)) ≈ permutedims(
+                    reduce((x,y) -> cat(x,y, dims=3), aa[:,i,i,:] for i in 1:4),(1,3,2))
+
+    # permutation
     @test einsum(((1,2),), (a,), (2,1)) ≈ permutedims(a,(2,1))
+    @test einsum(((1,2,3,4),), (t,),(2,3,1,4)) ≈ permutedims(t,(2,3,1,4))
+
+    # tensor contraction
     ta = zeros(size(t)[[1,2]]...)
     for (i,j,k,l) in Iterators.product(1:2,1:2,1:2,1:2)
         ta[i,l] += t[i,j,k,l] * a[j,k]
@@ -25,14 +45,36 @@ using Test
     end
     @test einsum(((4,3,2,1), (2,3)), (t,a),(1,4)) ≈  ta
 
+    # star-contraction
     aaa = zeros(2,2,2);
     for (i,j,k,l) in Iterators.product(1:2,1:2,1:2,1:2)
         aaa[j,k,l] += a[i,j] * a[i,k] * a[i,l]
     end
     @test aaa ≈ einsum(((1,2),(1,3),(1,4)), (a,a,a))
 
-    let p = (2,3,1,4)
-        @test einsum(((1,2,3,4),), (t,),p) ≈ permutedims(t,p)
+    # star and contract
+    aaa = zeros(2);
+    for (i,j,l) in Iterators.product(1:2,1:2,1:2)
+        aaa[l] += a[i,j] * a[i,j] * a[i,l]
     end
+    @test einsum(((1,2),(1,2),(1,3)), (a,a,a), (3,)) ≈ aaa
+
+    # index-sum
+    a = rand(2,2,5)
+    @test einsum(((1,2,3),),(a,),(1,2)) ≈ sum(a, dims=3)
+
+    # Hadamard product
+    a = rand(2,3)
+    b = rand(2,3)
+    @test einsum(((1,2),(1,2)), (a,b), (1,2)) ≈ a .* b
+
+    # Outer
+    a = rand(2,3)
+    b = rand(2,3)
+    ab = zeros(2,3,2,3)
+    for (i,j,k,l) in Iterators.product(1:2,1:3,1:2,1:3)
+        ab[i,j,k,l] = a[i,j] * b[k,l]
+    end
+    @test einsum(((1,2),(3,4)),(a,b),(1,2,3,4)) ≈ ab
 
 end


### PR DESCRIPTION
Implementation based on broadcasting * and summing over contracted 
dimensions. Can't take traces or diagonals but allows contractions and 
star-contractions.