### PR TITLE
Draft a benchmark-file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
+*.json
 .DS_Store
 /Manifest.toml
 /docs/build/

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "ebe7aa44-baf0-506c-a96f-8464559b3922"
 authors = ["Andreas Peter <andreas.peter.ch@gmail.com>"]
 version = "0.1.0"
 
+[deps]
+PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -24,7 +24,7 @@ end
 SUITE["batchmul"] = BenchmarkGroup()
 suite = SUITE["batchmul"]
 function foo(m)
-    cat( m[:,:,i] * m[:,:,i] for i in axes(m,3), dims=3)
+    reduce((x,y) -> cat(x,y, dims=3), [m[:,:,i] * m[:,:,i] for i in axes(m,3)])
 end
 
 for T in (Float32, Float64, ComplexF32, ComplexF64)

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -89,7 +89,7 @@ end
 SUITE["diag"] = BenchmarkGroup()
 suite = SUITE["diag"]
 function foo(m)
-    permutedims(reduce((x,y) -> cat(x,y, dims=3), m[:,i,i,:] for i in axes(m,2)), (1,3,2))
+    reduce((x,y) -> cat(x,y, dims=2), m[:,i,i] for i in axes(m,2))
 end
 for T in (Float32, Float64, ComplexF32, ComplexF64)
     suite[string(T)] = BenchmarkGroup()
@@ -120,7 +120,7 @@ for T in (Float32, Float64, ComplexF32, ComplexF64)
     end
 end
 
-#permutation
+# tensor contraction
 SUITE["tcontract"] = BenchmarkGroup()
 suite = SUITE["tcontract"]
 function foo(x,y)
@@ -144,7 +144,7 @@ for T in (Float32, Float64, ComplexF32, ComplexF64)
     end
 end
 
-#permutation
+# star contraction
 SUITE["star"] = BenchmarkGroup()
 suite = SUITE["star"]
 function foo(x,y,z)

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,244 @@
+using BenchmarkTools
+using Random
+using LinearAlgebra
+
+Random.seed!(0)
+
+const SUITE = BenchmarkGroup()
+
+# Matrix multiplication
+SUITE["matmul"] = BenchmarkGroup()
+suite = SUITE["matmul"]
+for T in (Float32, Float64, ComplexF32, ComplexF64)
+    suite[string(T)] = BenchmarkGroup()
+    args = ["tiny"   => rand(T,2,2),
+            "small"  => rand(T,10,10),
+            "medium" => rand(T,10^2,10^2),
+            "large"  => rand(T, 10^3,10^3)]
+    for (k,m) in args
+        suite[string(T)][k] = @benchmarkable $m * $m
+    end
+end
+
+# Matrix batch-multiplication
+SUITE["batchmul"] = BenchmarkGroup()
+suite = SUITE["batchmul"]
+function foo(m)
+    cat( m[:,:,i] * m[:,:,i] for i in axes(m,3), dims=3)
+end
+
+for T in (Float32, Float64, ComplexF32, ComplexF64)
+    suite[string(T)] = BenchmarkGroup()
+    args = ["tiny"   => rand(T,2,2,3),
+            "small"  => rand(T,10,10,3),
+            "medium" => rand(T,10^2,10^2,3),
+            "large"  => rand(T, 10^3,10^3,3)]
+    for (k,m) in args
+        suite[string(T)][k] = @benchmarkable foo($m)
+    end
+end
+
+#inner - reduction to scalar
+SUITE["dot"] = BenchmarkGroup()
+suite = SUITE["dot"]
+for T in (Float32, Float64, ComplexF32, ComplexF64)
+    suite[string(T)] = BenchmarkGroup()
+    args = ["tiny"   => rand(T,fill(2,3)...)
+            "small"  => rand(T,fill(10,3)...)
+            "medium" => rand(T,fill(20,3)...)
+            "large"  => rand(T,fill(50,3)...)
+            "huge"   => rand(T,fill(10^2,3)...)]
+    for (k,m) in args
+        suite[string(T)][k] = @benchmarkable dot($m, $m)
+    end
+end
+
+#trace
+SUITE["trace"] = BenchmarkGroup()
+suite = SUITE["trace"]
+for T in (Float32, Float64, ComplexF32, ComplexF64)
+    suite[string(T)] = BenchmarkGroup()
+    args = ["tiny"   => rand(T,fill(2,2)...)
+            "small"  => rand(T,fill(10,2)...)
+            "medium" => rand(T,fill(10^2,2)...)
+            "large"  => rand(T,fill(10^3,2)...)]
+    for (k,m) in args
+        suite[string(T)][k] = @benchmarkable tr($m)
+    end
+end
+
+#partial trace
+SUITE["ptrace"] = BenchmarkGroup()
+suite = SUITE["ptrace"]
+function foo(x)
+    sum(x[i,i,:] for i in axes(x,1))
+end
+for T in (Float32, Float64, ComplexF32, ComplexF64)
+    suite[string(T)] = BenchmarkGroup()
+    args = ["tiny"   => rand(T,fill(2,3)...)
+            "small"  => rand(T,fill(10,3)...)
+            "medium" => rand(T,fill(20,3)...)
+            "large"  => rand(T,fill(50,3)...)
+            "huge"   => rand(T,fill(10^2,3)...)]
+    for (k,m) in args
+        suite[string(T)][k] = @benchmarkable foo($m)
+    end
+end
+
+#diagonal
+SUITE["diag"] = BenchmarkGroup()
+suite = SUITE["diag"]
+function foo(m)
+    permutedims(reduce((x,y) -> cat(x,y, dims=3), m[:,i,i,:] for i in axes(m,2)), (1,3,2))
+end
+for T in (Float32, Float64, ComplexF32, ComplexF64)
+    suite[string(T)] = BenchmarkGroup()
+    args =  [
+            "tiny"   => rand(T,fill(2,3)...)
+            "small"  => rand(T,fill(10,3)...)
+            "medium" => rand(T,fill(20,3)...)
+            "large" => rand(T,fill(30,3)...)
+            ]
+    for (k,m) in args
+        suite[string(T)][k] = @benchmarkable foo($m)
+    end
+end
+
+#permutation
+SUITE["perm"] = BenchmarkGroup()
+suite = SUITE["perm"]
+for T in (Float32, Float64, ComplexF32, ComplexF64)
+    suite[string(T)] = BenchmarkGroup()
+    args =  [
+            "tiny"   => rand(T,fill(1,4)...)
+            "small"  => rand(T,fill(2,4)...)
+            "medium" => rand(T,fill(10,4)...)
+            "large"  => rand(T,fill(30,4)...)
+            ]
+    for (k,m) in args
+        suite[string(T)][k] = @benchmarkable permutedims($m, (4,2,3,1))
+    end
+end
+
+#permutation
+SUITE["tcontract"] = BenchmarkGroup()
+suite = SUITE["tcontract"]
+function foo(x,y)
+    xy = zeros(eltype(x),size(x,1), size(y,2))
+    for (i,j,k,l) in Iterators.product(axes(x,1), axes(y,2), axes(x,2), axes(y,3))
+        xy[i,j] += x[i,k,l] * y[k,j,l]
+    end
+    return xy
+end
+for T in (Float32, Float64, ComplexF32, ComplexF64)
+    suite[string(T)] = BenchmarkGroup()
+    args =  [
+            "tiny"   => rand(T,fill(1,3)...)
+            "small"  => rand(T,fill(2,3)...)
+            "medium" => rand(T,fill(10,3)...)
+            "large"  => rand(T,fill(30,3)...)
+            ]
+
+    for (k,m) in args
+        suite[string(T)][k] = @benchmarkable foo($m,$m)
+    end
+end
+
+#permutation
+SUITE["star"] = BenchmarkGroup()
+suite = SUITE["star"]
+function foo(x,y,z)
+    xyz = zeros(eltype(x),size(x,2), size(y,2), size(z,2))
+    for (i,j,k,l) in Iterators.product(axes(x,1), axes(x,2), axes(y,2), axes(z,2))
+        xyz[j,k,l] += x[i,j] * y[i,k] * z[i,l]
+    end
+    return xy
+end
+for T in (Float32, Float64, ComplexF32, ComplexF64)
+    suite[string(T)] = BenchmarkGroup()
+    args =  [
+            "tiny"   => rand(T,fill(2,2)...)
+            "small"  => rand(T,fill(10,2)...)
+            "medium" => rand(T,fill(30,2)...)
+            "large"  => rand(T,fill(100,2)...)
+            ]
+    for (k,m) in args
+        suite[string(T)][k] = @benchmarkable foo($m,$m)
+    end
+end
+
+#star and contract
+SUITE["star&contract"] = BenchmarkGroup()
+suite = SUITE["star&contract"]
+function foo(x,y,z)
+    xyz = zeros(size(x,2))
+    for (i,j,k,l) in Iterators.product(axes(x,1), axes(x,2), axes(y,2), axes(z,2))
+        xyz[j] += x[i,j] * y[i,l] * z[i,l]
+    end
+    return xy
+end
+for T in (Float32, Float64, ComplexF32, ComplexF64)
+    suite[string(T)] = BenchmarkGroup()
+    args =  [
+            "tiny"   => rand(T,fill(2,2)...)
+            "small"  => rand(T,fill(10,2)...)
+            "medium" => rand(T,fill(30,2)...)
+            "large"  => rand(T,fill(100,2)...)
+            ]
+    for (k,m) in args
+        suite[string(T)][k] = @benchmarkable foo($m,$m)
+    end
+end
+
+# index-sum
+SUITE["indexsum"] = BenchmarkGroup()
+suite = SUITE["indexsum"]
+for T in (Float32, Float64, ComplexF32, ComplexF64)
+    suite[string(T)] = BenchmarkGroup()
+    args =  [
+            "tiny"   => rand(T,fill(2,3)...)
+            "small"  => rand(T,fill(10,3)...)
+            "medium" => rand(T,fill(30,3)...)
+            "large"  => rand(T,fill(100,3)...)
+            ]
+    for (k,m) in args
+        suite[string(T)][k] = @benchmarkable sum($m, dims=2)
+    end
+end
+
+# Hadamard
+SUITE["hadamard"] = BenchmarkGroup()
+suite = SUITE["hadamard"]
+for T in (Float32, Float64, ComplexF32, ComplexF64)
+    suite[string(T)] = BenchmarkGroup()
+    args =  [
+            "tiny"   => rand(T,fill(2,3)...)
+            "small"  => rand(T,fill(10,3)...)
+            "medium" => rand(T,fill(30,3)...)
+            "large"  => rand(T,fill(100,3)...)
+            ]
+    for (k,m) in args
+        suite[string(T)][k] = @benchmarkable $m .* $m
+    end
+end
+
+# Outer
+SUITE["outer"] = BenchmarkGroup()
+suite = SUITE["outer"]
+function foo(x,y)
+    xp = reshape(x, size(x)...,1,1)
+    yp = reshape(y, 1,1,size(y)...)
+    xp .* yp
+end
+for T in (Float32, Float64, ComplexF32, ComplexF64)
+    suite[string(T)] = BenchmarkGroup()
+    args =  [
+            "tiny"   => rand(T,fill(2,2)...)
+            "small"  => rand(T,fill(10,2)...)
+            "medium" => rand(T,fill(50,2)...)
+            "large"  => rand(T,fill(100,2)...)
+            ]
+    for (k,m) in args
+        suite[string(T)][k] = @benchmarkable foo($m, $m)
+    end
+end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -98,6 +98,7 @@ for T in (Float32, Float64, ComplexF32, ComplexF64)
             "small"  => rand(T,fill(10,3)...)
             "medium" => rand(T,fill(20,3)...)
             "large" => rand(T,fill(30,3)...)
+            "huge" => rand(T,fill(100,3)...)
             ]
     for (k,m) in args
         suite[string(T)][k] = @benchmarkable mydiag($m)

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -169,8 +169,8 @@ for T in (Float32, Float64, ComplexF32, ComplexF64)
 end
 
 #star and contract
-SUITE["star&contract"] = BenchmarkGroup()
-suite = SUITE["star&contract"]
+SUITE["starandcontract"] = BenchmarkGroup()
+suite = SUITE["starandcontract"]
 function starandcontract(x,y,z)
     xyz = zeros(eltype(x),size(x,2))
     for (i,j,k,l) in Iterators.product(axes(x,1), axes(x,2), axes(y,2), axes(z,2))


### PR DESCRIPTION
Benchmarks everything from the possible features with naive julia 
implementations. Just to set the structure that all 
branches/implementations should use to compare performance. While 
comparison between commits/branches should be easy, within is less 
trivial - e.g. comparing "Float64" with "Float32" across all operations 
doesn't work by judge-ing SUITE[@tagged ...].

Could be merged to any branch that requires a benchmark-suite as soon as we're happy with the design.