### PR TITLE
Enable einsum (w/o bang) AD and add tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Andreas Peter <andreas.peter.ch@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+IRTools = "7869d1d1-7146-5819-86e3-90919afe41df"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
 TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -36,6 +36,7 @@ If `verbose=true`, print `f(x) - f(x - ηg)`and `η|g|²`.
 "
 function bpcheck(f, args...; η = 1e-5, verbose = false)
     g = gradient(f, args...)
+    all(==(nothing), g) && error()
     dy_ref = 0
     for x in g
         x === nothing && continue

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -17,7 +17,7 @@ end
 
 @Zygote.adjoint function einsum!(ixs, xs::NTuple{N,T where T}, iy, y) where N
     einsum!(ixs, xs, iy, y)
-    return y, dy -> let cdy = conj!(copy(dy))
+    return y, dy -> let cdy = map(conj,dy)
                 (
                     nothing,
                     ntuple(i -> einsum_grad(ixs, xs, iy, cdy, i), N),
@@ -50,3 +50,5 @@ function bpcheck(f, args...; η = 1e-5, verbose = false)
 
     isapprox(dy, dy_ref, rtol=1e-2, atol=1e-8)
 end
+
+@Zygote.nograd outputtensor

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -39,7 +39,6 @@ function einsum(contractions::NTuple{N, NTuple{M, T} where M},
                 outinds::NTuple{<:Any,T}) where {N,T}
     out = outputtensor(tensors, contractions, outinds)
     einsum!(contractions, tensors, outinds, out)
-    return out
 end
 
 function outputtensor(tensors, contractions, outinds)

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -1,109 +1,112 @@
 using Test
 using OMEinsum: bpcheck, einsum!
+using OMEinsum
 using Zygote
 
-@testset "einsum bp" begin
-    @testset "real" begin
-        T = Float64
-        # matrix and vector multiplication
-        a,b,c = rand(T,2,2), rand(T,2,2), rand(T,2,2)
-        v = rand(T,2)
-        t = randn(2,2,2,2)
-        @test bpcheck( (a,b,c) -> einsum!(((1,2),(2,3),(3,4)), (a,b,c), (1,4), zeros(T,2,2)) |> abs ∘ sum ,a,b,c)
+@testset "einsum! bp" begin
+    for T in (Float64, ComplexF64)
+        @testset "$T" begin
+            # matrix and vector multiplication
+            a,b,c = rand(T,2,2), rand(T,2,2), rand(T,2,2)
+            v = rand(T,2)
+            t = randn(2,2,2,2)
+            @test bpcheck( (a,b,c) -> einsum!(((1,2),(2,3),(3,4)), (a,b,c), (1,4), zeros(T,2,2)) |> abs ∘ sum ,a,b,c)
 
-        @test bpcheck( (a,b,c) -> einsum!(((1,2),(2,3),(3,4)), (a,b,c), (4,1), zeros(T,2,2)) |> abs ∘ sum ,a,b,c)
+            @test bpcheck( (a,b,c) -> einsum!(((1,2),(2,3),(3,4)), (a,b,c), (4,1), zeros(T,2,2)) |> abs ∘ sum ,a,b,c)
 
-        @test bpcheck((a,v) -> einsum!(((1,2),(2,)), (a,v), (1,), zeros(T,2)) |> abs ∘ sum , a, v)
+            @test bpcheck((a,v) -> einsum!(((1,2),(2,)), (a,v), (1,), zeros(T,2)) |> abs ∘ sum , a, v)
 
-        # contract to 0-dim array
-        @test bpcheck((a,b) -> einsum!(((1,2),(1,2)), (a,b), (), zeros(T)) |> abs ∘ sum , a,b)
+            # contract to 0-dim array
+            @test bpcheck((a,b) -> einsum!(((1,2),(1,2)), (a,b), (), zeros(T)) |> abs ∘ sum , a,b)
 
-        # trace
-        @test bpcheck(a -> einsum!(((1,1),), (a,), (), zeros(T)) |> abs ∘ sum, a)
-        aa = rand(T,2,4,4,2)
-        @test bpcheck(aa -> einsum!(((1,2,2,1),), (aa,), (), zeros(T)) |> abs ∘ sum, aa)
+            # trace
+            @test bpcheck(a -> einsum!(((1,1),), (a,), (), zeros(T)) |> abs ∘ sum, a)
+            aa = rand(T,2,4,4,2)
+            @test bpcheck(aa -> einsum!(((1,2,2,1),), (aa,), (), zeros(T)) |> abs ∘ sum, aa)
 
 
-        # partial trace
-        @test bpcheck(aa -> einsum!(((1,2,2,3),), (aa,), (1,3), zeros(T,2,2)) |> abs ∘ sum, aa)
+            # partial trace
+            @test bpcheck(aa -> einsum!(((1,2,2,3),), (aa,), (1,3), zeros(T,2,2)) |> abs ∘ sum, aa)
 
-        # diag
-        @test bpcheck(aa -> einsum!(((1,2,2,3),), (aa,), (1,2,3), zeros(T,2,4,2)) |> abs ∘ sum, aa)
+            # diag
+            @test bpcheck(aa -> einsum!(((1,2,2,3),), (aa,), (1,2,3), zeros(T,2,4,2)) |> abs ∘ sum, aa)
 
-        # permutation
-        @test bpcheck(a -> einsum!(((1,2),), (a,), (2,1), zeros(T,2,2)) |> abs ∘ sum, a)
-        @test bpcheck(t -> einsum!(((1,2,3,4),), (t,),(2,3,1,4), zeros(T,2,2,2,2)) |> abs ∘ sum, t)
+            # permutation
+            @test bpcheck(a -> einsum!(((1,2),), (a,), (2,1), zeros(T,2,2)) |> abs ∘ sum, a)
+            @test bpcheck(t -> einsum!(((1,2,3,4),), (t,),(2,3,1,4), zeros(T,2,2,2,2)) |> abs ∘ sum, t)
 
-        # tensor contraction
-        @test bpcheck((t,a) -> einsum!(((1,2,3,4), (2,3)), (t,a), (1,4), zeros(T,2,2)) |> abs ∘ sum, t,a)
-        @test bpcheck((t,a) -> einsum!(((4,3,2,1), (2,3)), (t,a), (1,4), zeros(T,2,2)) |> abs ∘ sum, t,a)
+            # tensor contraction
+            @test bpcheck((t,a) -> einsum!(((1,2,3,4), (2,3)), (t,a), (1,4), zeros(T,2,2)) |> abs ∘ sum, t,a)
+            @test bpcheck((t,a) -> einsum!(((4,3,2,1), (2,3)), (t,a), (1,4), zeros(T,2,2)) |> abs ∘ sum, t,a)
 
-        # star-contraction
-        @test bpcheck((a,b,c) -> einsum!(((1,2),(1,3),(1,4)), (a,b,c), (2,3,4), zeros(T,2,2,2)) |> abs ∘ sum, a,b,c)
+            # star-contraction
+            @test bpcheck((a,b,c) -> einsum!(((1,2),(1,3),(1,4)), (a,b,c), (2,3,4), zeros(T,2,2,2)) |> abs ∘ sum, a,b,c)
 
-        # star and contract
-        @test bpcheck((a,b,c) -> einsum!(((1,2),(1,2),(1,3)), (a,b,c), (3,), zeros(T,2)) |> abs ∘ sum, a,b,c)
+            # star and contract
+            @test bpcheck((a,b,c) -> einsum!(((1,2),(1,2),(1,3)), (a,b,c), (3,), zeros(T,2)) |> abs ∘ sum, a,b,c)
 
-        # index-sum
-        a3 = rand(T,2,2,2)
-        @test bpcheck(a -> einsum!(((1,2,3),),(a,),(1,2), zeros(T,2,2)) |> abs ∘ sum, a3)
+            # index-sum
+            a3 = rand(T,2,2,2)
+            @test bpcheck(a -> einsum!(((1,2,3),),(a,),(1,2), zeros(T,2,2)) |> abs ∘ sum, a3)
 
-        # Hadamard product
-        @test bpcheck((a,b) -> einsum!(((1,2),(1,2)), (a,b), (1,2), zeros(T,2,2)) |> abs ∘ sum, a, b)
+            # Hadamard product
+            @test bpcheck((a,b) -> einsum!(((1,2),(1,2)), (a,b), (1,2), zeros(T,2,2)) |> abs ∘ sum, a, b)
 
-        # Outer
-        @test bpcheck((a,b) -> einsum!(((1,2),(3,4)),(a,b),(1,2,3,4), zeros(T,2,2,2,2)) |> abs ∘ sum, a, b)
+            # Outer
+            @test bpcheck((a,b) -> einsum!(((1,2),(3,4)),(a,b),(1,2,3,4), zeros(T,2,2,2,2)) |> abs ∘ sum, a, b)
+        end
     end
+end
 
-    @testset "complex" begin
-        T = ComplexF64
-        # matrix and vector multiplication
-        a,b,c = rand(T,2,2), rand(T,2,2), rand(T,2,2)
-        v = rand(T,2)
-        t = randn(2,2,2,2)
-        @test bpcheck( (a,b,c) -> einsum!(((1,2),(2,3),(3,4)), (a,b,c), (1,4), zeros(T,2,2)) |> abs ∘ sum ,a,b,c)
+@testset "einsum bp" begin
+    for T in (Float64, ComplexF64)
+        @testset "$T" begin
+            # matrix and vector multiplication
+            a,b,c = rand(T,2,2), rand(T,2,2), rand(T,2,2)
+            v = rand(T,2)
+            t = randn(2,2,2,2)
+            @test bpcheck( (a,b,c) -> einsum(((1,2),(2,3),(3,4)), (a,b,c), (1,4)) |> abs ∘ sum ,a,b,c)
+            @test bpcheck( (a,b,c) -> einsum(((1,2),(2,3),(3,4)), (a,b,c), (4,1)) |> abs ∘ sum ,a,b,c)
+            @test bpcheck((a,v) -> einsum(((1,2),(2,)), (a,v), (1,)) |> abs ∘ sum , a, v)
 
-        @test bpcheck( (a,b,c) -> einsum!(((1,2),(2,3),(3,4)), (a,b,c), (4,1), zeros(T,2,2)) |> abs ∘ sum ,a,b,c)
+            # contract to 0-dim array
+            @test bpcheck((a,b) -> einsum(((1,2),(1,2)), (a,b), ()) |> abs ∘ sum , a,b)
 
-        @test bpcheck((a,v) -> einsum!(((1,2),(2,)), (a,v), (1,), zeros(T,2)) |> abs ∘ sum , a, v)
-
-        # contract to 0-dim array
-        @test bpcheck((a,b) -> einsum!(((1,2),(1,2)), (a,b), (), zeros(T)) |> abs ∘ sum , a,b)
-
-        # trace
-        @test bpcheck(a -> einsum!(((1,1),), (a,), (), zeros(T)) |> abs ∘ sum, a)
-        aa = rand(T,2,4,4,2)
-        @test bpcheck(aa -> einsum!(((1,2,2,1),), (aa,), (), zeros(T)) |> abs ∘ sum, aa)
+            # trace
+            @test bpcheck(a -> einsum(((1,1),), (a,), ()) |> abs ∘ sum, a)
+            aa = rand(T,2,4,4,2)
+            @test bpcheck(aa -> einsum(((1,2,2,1),), (aa,), ()) |> abs ∘ sum, aa)
 
 
-        # partial trace
-        @test bpcheck(aa -> einsum!(((1,2,2,3),), (aa,), (1,3), zeros(T,2,2)) |> abs ∘ sum, aa)
+            # partial trace
+            @test bpcheck(aa -> einsum(((1,2,2,3),), (aa,), (1,3)) |> abs ∘ sum, aa)
 
-        # diag
-        @test bpcheck(aa -> einsum!(((1,2,2,3),), (aa,), (1,2,3), zeros(T,2,4,2)) |> abs ∘ sum, aa)
+            # diag
+            @test bpcheck(aa -> einsum(((1,2,2,3),), (aa,), (1,2,3)) |> abs ∘ sum, aa)
 
-        # permutation
-        @test bpcheck(a -> einsum!(((1,2),), (a,), (2,1), zeros(T,2,2)) |> abs ∘ sum, a)
-        @test bpcheck(t -> einsum!(((1,2,3,4),), (t,),(2,3,1,4), zeros(T,2,2,2,2)) |> abs ∘ sum, t)
+            # permutation
+            @test bpcheck(a -> einsum(((1,2),), (a,), (2,1)) |> abs ∘ sum, a)
+            @test bpcheck(t -> einsum(((1,2,3,4),), (t,),(2,3,1,4)) |> abs ∘ sum, t)
 
-        # tensor contraction
-        @test bpcheck((t,a) -> einsum!(((1,2,3,4), (2,3)), (t,a), (1,4), zeros(T,2,2)) |> abs ∘ sum, t,a)
-        @test bpcheck((t,a) -> einsum!(((4,3,2,1), (2,3)), (t,a), (1,4), zeros(T,2,2)) |> abs ∘ sum, t,a)
+            # tensor contraction
+            @test bpcheck((t,a) -> einsum(((1,2,3,4), (2,3)), (t,a), (1,4)) |> abs ∘ sum, t,a)
+            @test bpcheck((t,a) -> einsum(((4,3,2,1), (2,3)), (t,a), (1,4)) |> abs ∘ sum, t,a)
 
-        # star-contraction
-        @test bpcheck((a,b,c) -> einsum!(((1,2),(1,3),(1,4)), (a,b,c), (2,3,4), zeros(T,2,2,2)) |> abs ∘ sum, a,b,c)
+            # star-contraction
+            @test bpcheck((a,b,c) -> einsum(((1,2),(1,3),(1,4)), (a,b,c), (2,3,4)) |> abs ∘ sum, a,b,c)
 
-        # star and contract
-        @test bpcheck((a,b,c) -> einsum!(((1,2),(1,2),(1,3)), (a,b,c), (3,), zeros(T,2)) |> abs ∘ sum, a,b,c)
+            # star and contract
+            @test bpcheck((a,b,c) -> einsum(((1,2),(1,2),(1,3)), (a,b,c), (3,)) |> abs ∘ sum, a,b,c)
 
-        # index-sum
-        a3 = rand(T,2,2,2)
-        @test bpcheck(a -> einsum!(((1,2,3),),(a,),(1,2), zeros(T,2,2)) |> abs ∘ sum, a3)
+            # index-sum
+            a3 = rand(T,2,2,2)
+            @test bpcheck(a -> einsum(((1,2,3),),(a,),(1,2)) |> abs ∘ sum, a3)
 
-        # Hadamard product
-        @test bpcheck((a,b) -> einsum!(((1,2),(1,2)), (a,b), (1,2), zeros(T,2,2)) |> abs ∘ sum, a, b)
+            # Hadamard product
+            @test bpcheck((a,b) -> einsum(((1,2),(1,2)), (a,b), (1,2)) |> abs ∘ sum, a, b)
 
-        # Outer
-        @test bpcheck((a,b) -> einsum!(((1,2),(3,4)),(a,b),(1,2,3,4), zeros(T,2,2,2,2)) |> abs ∘ sum, a, b)
+            # Outer
+            @test bpcheck((a,b) -> einsum(((1,2),(3,4)),(a,b),(1,2,3,4)) |> abs ∘ sum, a, b)
+        end
     end
 end


### PR DESCRIPTION
Zygote triped over `out` being returned which is allocated by 
`outtensor` but should only be considered as the result of `einsum!`. We 
return `out`via `einsum!`whose adjoint works already.

@GiggleLiu  should we remove the tests for `einsum!` if the tests for `einsum`rely on `einsum!` under the hood or is this duplication ok?