### PR TITLE
make index more flexible

### DIFF
--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -61,9 +61,9 @@ function einsum!(ixs::NTuple{N, NTuple{M, IT} where M},
 
     ci = CartesianIndices(sizes)
     locs_xs = map(ixs) do ix
-        map(i -> findfirst(==(i), indices)::Int64, ix)
+        map(i -> findfirst(==(i), indices)::Int, ix)
     end
-    locs_y = map(i -> findfirst(==(i), indices)::Int64, iy)
+    locs_y = map(i -> findfirst(==(i), indices)::Int, iy)
 
     loop!(locs_xs, xs, locs_y, y, ci)
 end

--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -88,6 +88,13 @@ end
     @test allocs2 < 1.1 * allocs1
 end
 
+@testset "more flexible indexing type" begin
+    # Char - interface, matmul
+    a = rand(2,2)
+    b = rand(2,3)
+    @test einsum((('a','b'),('b','c')),(a,b),('a','c')) ≈ a*b
+end
+
 @testset "error handling" begin
     a = randn(3,3)
     b = randn(4,4)


### PR DESCRIPTION
Now `einsum` allows this kind of input
```
@test einsum((('a','b'), ('b','c')), (A,B), ('a','c')) ≈ A*B
```

This kind of interface can increasing readability in some context.
Wondering if it worth make the interface more flexible.