### PR TITLE
einsum design

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,10 @@ authors = ["Andreas Peter <andreas.peter.ch@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 IRTools = "7869d1d1-7146-5819-86e3-90919afe41df"
 PkgBenchmark = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+TensorOperations = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,152 @@ alt="OMEinsum logo" width="510"></img>
 This is a repository for the _Google Summer of Code_ project on Differentiable Tensor Networks.
 It is a work in progress and will **change substantially this summer (2019)** - no guarantees can be made.
 
-The goal is to implement an `einsum`-like function, see e.g. the Numpy documentation [here](https://docs.scipy.org/doc/numpy/reference/generated/numpy.einsum.html).
-The ability to both define contractions at runtime and have efficient contractions if indices are shared between more than two tensors will set `OMEinsum` apart from the existing tools like
-[`Einsum.jl`](https://github.com/ahwillia/Einsum.jl),
-where contractions have to be written explicitly in the code,
-and [`TensorOperations.jl`](https://github.com/Jutho/TensorOperations.jl),
-which can not handle more general contractions.
+This package exports two functions, `einsum` and `einsumopt`.
+`einsum` implements functionality similar to the `einsum` function in `numpy`,
+although some details are different.
+`einsumopt` receives the same arguments as `einsum` but optimizes the order
+of operations that are evaluated internally which might lead to better performance
+in some cases.
+
+`einsum` operations are specified by a tuple of tensors `xs = (x1, x2, x3...)`
+and a tuple of index-labels for the tensors in `xs`, `ixs = (ix1, ix2, ix3...)`,
+optionally an output index-labels can be specified `iy` as `einsum(ixs, xs, iy)`.
+
+Let `l` be the set of all unique labels in the `ixs` without the ones in `iy`.
+`einsum` then calculates an output tensor `y` with indices labelled `iy` according
+to the following specification:
+```
+∀ iy : y[iy] = ∑ₗ x1[ix1] * x2[ix2] * x3[ix3] ...
+```
+where the sum over `l` implies the sum over all possible values of the labels in `l`.
+
+As an example, consider multiplying two matrices `a` and `b` which we specify with
+```julia
+julia> a, b = rand(2,2), rand(2,2);
+
+julia> einsum((('i','k'),('k','j')), (a,b), ('i','j'))
+```
+where we have
+* `x1 = a`
+* `ix1 = ('i','k')`
+* `x2 = b`
+* `ix2 = ('k','j')`
+* `iy = ('i','j')`.
+
+The set of unique labels in the `ixs = (ix1,ix2)` without the ones in `iy` is then
+`l = ('k',)`.
+So the output `y` will satisfy
+```
+∀ ('i','j'): y[i,j] = ∑ₖ a[i,k] * b[k,j]
+```
+just like we'd expect from a matrix-product.
+
+To find out more about einsum, check out my [nextjournal-article](https://nextjournal.com/under-Peter/julia-summer-of-einsum) or the [numpy-manual](https://docs.scipy.org/doc/numpy/reference/generated/numpy.einsum.html).
+
+If we don't specify `iy`, it is constructed from all labels in the `ixs`  that
+appear exactly once in alphabetical (if labels are `<:AbstractChar`) or
+numerical (if labels are `<:Integer`) order.
+If `iy` is given, the specification is evaluated according to the _explicit_ mode in
+numpy's `einsum`, otherwise it's evaluated according to the _implicit_ mode.
+In the above case, it amounts to the same.
+
+We might instead be interested in the sum of all elements of the matrix product `a*b`
+and reduce over all indices, specifying `iy = ()`:
+```julia
+julia> xs = (rand(2,2), rand(2,2));
+
+julia> ixs = (('i','k'),('k','j'));
+
+julia> iy = ();
+
+julia> einsum(ixs, xs, iy) ≈  sum(a * b)
+true
+```
+
+`einsum` evaluates the specification `ixs,iy` as a sequence of operations on labels.
+The order those operations are evaluated in is given by the ordering of their labels.
+E.g. in
+```julia
+julia> a, b, c = rand(2,2), rand(2,2), rand(2,2);
+
+julia> einsum((('i','j'),('j','h'),('h','k')), (a,b,c), ('i','k')
+```
+there are two indices that require operations: `'j'` and `'h'` both imply a matrix
+product. They are evaluated in alphabetical order, i.e. first `'h'`, then `'j'`,
+corresponding to `(a*(b*c))`.
+
+If the order should instead be optimized automatically, use `einsumopt`.
+`einsumopt` will calculate the cost of each possible sequence of operations and evaluate
+the (possibly nonunique) optimal operations order.
+This is currently associated with a rather large overhead,
+but an example from physics with unfortunate default evaluation order shows that in some
+cases it might still be worth it:
+```julia
+julia> d = 5; χ = 50; a = randn(χ,χ); b= randn(χ,d,χ); c = randn(d,d,d,d);
+
+julia> @btime einsum((('x','y'), ('x','k','l'), ('y','m','n'), ('k','m','o','p')), ($a, $b, $b, $c), ('l','n','o','p'));
+  1.396 s (460 allocations: 2.33 GiB)
+
+julia> @btime einsumopt((('x','y'), ('x','k','l'), ('y','m','n'), ('k','m','o','p')), ($a, $b, $b, $c), ('l','n','o','p'));
+  2.579 ms (11789 allocations: 2.00 MiB)
+
+```
+although the same effect can be had by choosing the labels appropriately, such that
+the best contraction sequence is in alphabetical order:
+```julia
+julia> @btime einsum((('i','j'), ('i','k','l'), ('j','m','n'), ('k','m','o','p')), ($a, $b, $b, $c), ('l','n','o','p'));
+  773.467 μs (339 allocations: 1.54 MiB)
+```
+
+(The significant overhead of order optimisation is being worked on).
+
+## Implementation
+
+Under the hood, both `einsum` and `einsumopt` take the input indices `ixs` and `iy`
+and translate them to a list of _operators_ which are implemented as concrete subtypes
+of the abstract type `EinsumOp`.
+
+One such operator is `Trace(edges)` which holds the labels of the indices that can
+be traced over in one operation. An operator together with the tensors and input indices
+can be given to the (unexported) `evaluate` function which can dispatch on an
+appropriate method.
+Trace currently get dispatched to `tensortrace` from the `TensorOperations` package,
+whereas an index-reduction like `ij -> i` is represented by `IndexReduction(('i',))`
+and dispatches to the built-in `sum` over the appropriate dimension.
+
+The operators currently implemented are:
+* `TensorContract`: contract one or more indices from two tensors, e.g. `ijk,jkl -> il`
+* `Trace`: contract one or more index-pairs from one tensor, e.g. `iij -> j`
+* `StarContract`: contract one or more indices shared between three or more tensors but none of the tensors has duplicate shared indices, e.g. `ij,ik,il -> jkl`
+* `MixedStarContract`: contract one or more indices shared between three or more tensors but one or more of the tensors has duplicate shared indices, e.g. `ij,ik,iil -> jkl`
+* `Diag`: take the diagonal of one or more indices between multiple tensors but none of the tensors has duplicate shared indices, e.g. `ij,ik -> ij`
+* `MixedDiag`: take the diagonal of one or more indices between multiple tensors but one or more of the tensors has duplicate shared indices, e.g. `iij,ik -> ij`
+* `IndexReduction`: reduce over one or more indices of a tensor, e.g. `ij -> j`
+* `Permutation`: permute the indices of a tensor, e.g. `ijk -> jki`
+* `OuterProduct`: take the outer product of one or more tensors, e.g. `ij,kl -> ijkl`
+* `Fallback`: all operations not captured by the ones above, e.g. `ij -> iij`
+
+The operators are currently not extendable and have been chosen based on my knowledge on whether there's
+a more efficient implementation for an operator than the default.
+Thus e.g. I separate e.g. `MixedStarContract` and `MixedDiag` from their respective non-mixed version,
+because the nonmixed-version can be nicely calculated using `broadcast`.
+
+`einsum` currently combines operations that are compatible and act on the same tensors.
+In e.g. the double trace `ix = ('i','i','k','k')`, `iy = ()`, we can evaluate both
+the trace over `'k'` and `'i'` with one function call.
+
+This behaviour is controlled by `iscombineable(op1,op2)` which returns true if two operators can be combined and `combineops(op1,op2)` which is called if two consecutive operations satisfy `iscombineable` and act on the same tensor(s).
+
+
+## Differences to `numpy.einsum`
+
+Apart from the implementation-details, `OMEinsum.einsum` always returns copies, never views,
+whereas `numpy.einsum` might return a view e.g. in the case of a permutation.
+`OMEinsum.einsum` also doesn't support the use of ellipsis for unchanged variables, as in
+e.g. `numpy.einsum("ij... -> ji...",a)` which would swap the first two axes in `numpy`.
+
+
+## Contribute
 
 Suggestions and Comments in the _Issues_ are welcome.
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -198,7 +198,7 @@ for T in (Float32, Float64, ComplexF32, ComplexF64)
             "tiny"   => rand(T,fill(2,3)...)
             "small"  => rand(T,fill(10,3)...)
             "medium" => rand(T,fill(30,3)...)
-            "large"  => rand(T,fill(100,3)...)
+            # "large"  => rand(T,fill(100,3)...)
             ]
     for (k,m) in args
         suite[string(T)][k] = @benchmarkable einsum(((1,2,3),(1,2,3)), ($m,$m), (1,2,3))

--- a/src/OMEinsum.jl
+++ b/src/OMEinsum.jl
@@ -7,5 +7,6 @@ using TupleTools
 include("einsum.jl")
 include("autodiff.jl")
 include("einorder.jl")
+include("einevaluate.jl")
 
 end # module

--- a/src/OMEinsum.jl
+++ b/src/OMEinsum.jl
@@ -1,6 +1,6 @@
 module OMEinsum
 export einsum, expandall!
-export meinsumopt
+export einsumopt
 
 using TupleTools
 

--- a/src/OMEinsum.jl
+++ b/src/OMEinsum.jl
@@ -1,9 +1,11 @@
 module OMEinsum
 export einsum, expandall!
+export meinsumopt
 
 using TupleTools
 
 include("einsum.jl")
 include("autodiff.jl")
+include("einorder.jl")
 
 end # module

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -10,13 +10,15 @@ function einsum_grad(ixs, xs, iy, y, i)
     nixs = TupleTools.insertat(ixs, i, (iy,))
     nxs  = TupleTools.insertat( xs, i, ( y,))
     niy = ixs[i]
+    ntmp = Tuple(i for i in unique(niy) if any(x -> i in x, nixs))
+    tmp = einsum(nixs, nxs, ntmp)
     ny = zeros(T, size(xs[i])...)
-    einsum!(nixs, nxs, niy, ny)
+    einsumexp!((ntmp,), (tmp,), niy, ny)
     conj!(ny)
 end
 
-@Zygote.adjoint function einsum!(ixs, xs::NTuple{N,T where T}, iy, y) where N
-    einsum!(ixs, xs, iy, y)
+@Zygote.adjoint function einsum(ixs, xs::NTuple{N,T where T}, iy) where N
+    y = einsum(ixs, xs, iy)
     return y, dy -> let cdy = map(conj,dy)
                 (
                     nothing,

--- a/src/einevaluate.jl
+++ b/src/einevaluate.jl
@@ -1,8 +1,7 @@
 @doc raw"
     evaluateall(ixs, xs, ops,iy)
 evaluate the einsum specified by 'ixs -> iy' by going through all operations
-in `ops` in order applying index-permutations, outer products and expansions
-at the end.
+in `ops` in order.
 "
 function evaluateall(ixs, xs, ops, iy)
     _, (x,) = foldl(((ixs, xs), op) -> evaluate(op, ixs, xs), ops, init = (ixs, xs))

--- a/src/einevaluate.jl
+++ b/src/einevaluate.jl
@@ -1,0 +1,109 @@
+@doc raw"
+    evaluateall(ixs, xs, ops,iy)
+evaluate the einsum specified by 'ixs -> iy' by going through all operations
+in `ops` in order applying index-permutations, outer products and expansions
+at the end.
+"
+function evaluateall(ixs, xs, ops, iy)
+    res = foldl(((ixs, xs), op) -> evaluate(op, ixs, xs), ops, init = (ixs, xs))
+    return einsumexp(res...  ,iy)
+end
+
+@doc raw"
+    evaluate(op::EinsumOp, allixs, allxs)
+returns a tuple of xs and ixs that result from the evaluation of the
+operator `op`.
+"
+function evaluate(op::EinsumOp, allixs, allxs)
+    #generic fallback
+    e = op.edges
+    inds = Tuple(i for (i, ix) in enumerate(allixs) if !isempty(intersect(e,ix)))
+    ixs, nallixs = pickfromtup(allixs, inds)
+    xs,  nallxs  = pickfromtup(allxs, inds)
+
+    nix = indicesafterop(op, ixs)
+    nx = einsumexp(ixs, xs, nix)
+
+    return (nix, nallixs...), (nx, nallxs...)
+end
+
+function evaluate(op::IndexReduction{N}, allixs, allxs) where N
+    e = op.edges[1]
+
+    ind = findfirst(x -> e in x, allixs)::Int
+    (ix,), nallixs = pickfromtup(allixs, (ind,))
+    (x,),  nallxs  = pickfromtup(allxs,  (ind,))
+
+    inds = map(e -> findfirst(==(e), ix), op.edges)
+    nix = TupleTools.deleteat(ix, inds)
+    nx = dropdims(sum(x, dims = inds), dims = inds)
+
+    return (nallixs..., nix), (nallxs..., nx)
+end
+
+function evaluate(op::TensorContract, allixs, allxs)
+    e = op.edges
+    i1 = findfirst(x -> e[1] in x, allixs)::Int
+    i2 = findnext( x -> e[1] in x, allixs, i1+1)::Int
+    inds = (i1, i2)
+
+    (ia, ib), nallixs = pickfromtup(allixs, inds)
+    (a, b),   nallxs  = pickfromtup(allxs, inds)
+
+    ia, ib, rev = tcdups(ia, ib, e)
+    nix = indicesafterop(op, (ia,ib))
+    nx = tensorcontract(a,ia,b,ib,nix)
+    nix = undotcdups(nix, rev)
+
+    return (nix, nallixs...), (nx, nallxs...)
+end
+
+function tcdups(ia::NTuple{N}, ib::NTuple{M}, e) where {N,M}
+    # if there are duplicate indices in either ia or ib that are not tensor-contracted,
+    # we need to change labels because TensorOperations doesn't allow duplicate output labels
+    # the third return value encodes all information needed to undo this deduplication
+    imax = max(maximum(ia), maximum(ib))
+    ra = ntuple(identity,N)
+    rb = ntuple(identity,M)
+    ia2 = map(ra, ia) do i, a
+        ifelse(count(==(a), ia) > 1 || a in ib && a ∉ e, imax + i, a)
+    end
+    ib2 = map(rb, ib) do i, a
+        ifelse(count(==(a), ib) > 1 || a in ia && a ∉ e, imax + N + i, a)
+    end
+
+    ia2, ib2, (TupleTools.vcat(ia,ib), TupleTools.vcat(ia2, ib2))
+end
+
+undotcdups(nix, (iaib, ia2ib2)) = map(i -> iaib[findfirst(==(i), ia2ib2)], nix)
+
+function evaluate(op::Trace, allixs, allxs)
+    e = op.edges
+    inds = Tuple(i for (i, ix) in enumerate(allixs) if !isempty(intersect(e, ix)))
+    (ia, ), nallixs = pickfromtup(allixs, inds)
+    (a, ),  nallxs  = pickfromtup(allxs, inds)
+
+
+    ia, rev = tracedups(ia, e)
+
+    nix = indicesafterop(op, (ia,))
+    nx = tensortrace(a,ia,nix)
+
+    nix = undotracedups(nix, rev)
+
+    return (nix, nallixs...), (nx, nallxs...)
+end
+
+function tracedups(ia::NTuple{N}, e) where N
+    # if there are duplicate indices in ia that are not tensor-traced,
+    # we need to change labels because TensorOperations doesn't allow duplicate output labels
+    # the second return value encodes all information needed to undo this deduplication
+    iamax = maximum(ia)
+    r = ntuple(identity,N)
+    ib = map(r, ia) do i, a
+        ifelse(count(==(a), ia) > 1 && a ∉ e, iamax + i, a)
+    end
+    return ib, (ia,ib)
+end
+
+undotracedups(ix, (ia, ib)) = map(i -> ib[findfirst(==(i), ia)], ix)

--- a/src/einevaluate.jl
+++ b/src/einevaluate.jl
@@ -43,6 +43,7 @@ function evaluate(op::Permutation, allixs::NTuple{1,T where T}, allxs)
     (x,)  = allxs
     (ix,) = allixs
     perm = op.perm
+    nix = indicesafterop(op, ix)
     return (TupleTools.permute(ix, perm),), (permutedims(x, perm),)
 end
 

--- a/src/einorder.jl
+++ b/src/einorder.jl
@@ -167,7 +167,7 @@ function _modifyhelper((ops, ixs, op2, sop2), op, iy)
     end
 end
 
-supportinds(op, ixs) = Tuple(i for (i,ix) in enumerate(ixs) if op.edges[1] in ix)
+supportinds(op, ixs) = map(x -> op.edges[1] in x, ixs)
 
 function opsfrominds(ixs, iy)
     tmp = placeholdersfrominds(ixs, iy)
@@ -199,7 +199,7 @@ as well as the new indices and sizes after evaluation.
 "
 function opcost(op::EinsumOp, cost, allixs, allsxs::NTuple{M,NTuple{N,Int} where N} where M)
     e = op.edges
-    inds = Tuple(i for (i, ix) in enumerate(allixs) if !isempty(intersect(e,ix)))
+    inds = Tuple(i for (i, ix) in enumerate(allixs) if overlap(e,ix))
 
     ixs, nallixs = pickfromtup(allixs, inds)
     sxs, nallsxs = pickfromtup(allsxs, inds)
@@ -230,9 +230,12 @@ function pickfromtup(things, inds)
     (TupleTools.getindices(things, inds), TupleTools.deleteat(things, inds))
 end
 
+overlap(s1, s2) = any(x -> x in s1, s2)
+
+
 function indicesafteroperation(op::EinsumOp, allixs)
     e = op.edges
-    inds = Tuple(i for (i, ix) in enumerate(allixs) if !isempty(intersect(ix, e)))
+    inds = Tuple(i for (i, ix) in enumerate(allixs) if overlap(ix,e))
     ixs, nallixs = pickfromtup(allixs, inds)
     nix = indicesafterop(op, ixs)
     return (nix, nallixs...)

--- a/src/einorder.jl
+++ b/src/einorder.jl
@@ -86,16 +86,16 @@ the kind of operation that `edge` implies.
 function operatorfromedge(edge, ixs, iy)
     #it would be nice if this could be user extendible, maybe traits?
     edge == () &&  error()
-    allixs = TupleTools.vcat(ixs...)#reduce(vcat, collect.(ixs))
+    allixs = TupleTools.vcat(ixs...)
     ce = count(==(edge), allixs)
     ceiniy = count(==(edge), iy)
     ceinixs = count.(==(edge), ixs)
     if ce == 2 && ceiniy == 0
-        all(x -> x == 0 || x == 1, ceinixs) && return TensorContract(edge)
+        all(x -> x == 0 || x >= 1, ceinixs) && return TensorContract(edge)
         return Trace(edge)
     elseif  ce == 1 && ceiniy == 0
         return IndexReduction(edge)
-    elseif ce > 1 && ceiniy == 1
+    elseif ce > 1 && ceiniy >= 1
         #diagonal
         any(x -> x > 1, ceinixs) && return MixedDiag{count(ceinixs .> 0)}(edge)
         return Diag{ce}(edge)

--- a/src/einorder.jl
+++ b/src/einorder.jl
@@ -1,0 +1,303 @@
+using OMEinsum
+using TensorOperations
+#= einorder
+1) identify edges & their corresponding operations:
+    - tensorcontraction
+    - (partial) trace
+    - (partial) diagonal
+    - star-contraction between
+    - star-contraction mixed
+    - index reduction
+    - perm
+   and then construct list of all operations implied by the indices
+2. optimise order of operations for minimum total iterations (in the naive loop view)
+
+3. evaluate einsum in optimized order
+=#
+
+#=
+# TODO 
+#
+# 1. find optimal order with PlaceHolder op (only includes edge and whether to keep or not -> sufficient)
+# 2. when optimal order is found, step through and label the ops correctly
+# 3. then evaluate
+=#
+inds =
+    [
+        (((1,2),(2,3)),(1,3)), #matmul
+        (((1,2),(1,3),(1,4)),(2,3,4)), #star between
+        (((1,2),(1,3),(1,4),(3,4)),(2,)), #star&contract
+        (((1,2,3),(3,4,5),(5,6,7),(7,8,1)), (2,4,6,8)), #tensor
+        (((1,2),), (1,)), #index reduction
+        (((1,2,2),), (1,)), #partial trace
+        (((1,2,2),), (1,2)), #partial diagonal
+        (((1,2,2),(2,3)), (1,3)), #star mixed
+    ]
+
+@doc raw"
+    edgesfrominds(ixs,iy)
+return the edges of the ixs that imply an operation e.g. 
+in ixs = ((1,2),(2,3)), iy = (1,3), edge 2 
+requires a tensor contraction
+"
+function edgesfrominds(ixs,iy)
+    allixs = reduce(vcat, collect.(ixs))
+    uniqueallixs = unique(allixs)
+    # edges are indices that are not trivial
+    # indices are trivial if they appear once in the input and once in the output
+    pred(x) = !(count(==(x), allixs) == 1 && x in iy)
+    Tuple(filter(pred, uniqueallixs))
+end
+
+@doc raw"
+    EinsumOp
+abstract supertype of all einsum operations
+"
+abstract type EinsumOp end
+
+struct PlaceHolder{T} <: EinsumOp
+    edge::T
+    keep::Bool
+end
+
+struct TensorContract{T} <: EinsumOp
+    edge::T
+end
+
+struct Trace{T} <: EinsumOp
+    edge::T
+end
+
+struct StarContract{N,T} <: EinsumOp
+    edge::T
+end
+StarContract{N}(e) where N = StarContract{N,typeof(e)}(e)
+
+struct MixedStarContract{N,T} <: EinsumOp
+    edge::T
+end
+MixedStarContract{N}(e) where N = MixedStarContract{N,typeof(e)}(e)
+
+struct Diag{N,T} <: EinsumOp
+    edge::T
+end
+Diag{N}(e) where N = Diag{N,typeof(e)}(e)
+
+struct MixedDiag{N,T} <: EinsumOp
+    edge::T
+end
+MixedDiag{N}(e) where N = MixedDiag{N,typeof(e)}(e)
+
+struct IndexReduction{T} <: EinsumOp
+    edge::T
+end
+
+struct Permute <: EinsumOp
+end
+
+@doc raw"
+    operatorfromedge(edge, ixs, iy)
+returns a subtype of `EinsumOp` which specifies
+the kind of operation that `edge` implies.
+"
+function operatorfromedge(edge, ixs, iy)
+    #it would be nice if this could be user extendible, maybe traits?
+    edge == () &&  error()
+    allixs = reduce(vcat, collect.(ixs))
+    ce = count(==(edge), allixs)
+    ceiniy = count(==(edge), iy)
+    ceinixs = count.(==(edge), ixs)
+    if ce == 2 && ceiniy == 0
+        all(x -> x == 0 || x == 1, ceinixs) && return TensorContract(edge)
+        return Trace(edge)
+    elseif  ce == 1 && ceiniy == 0
+        return IndexReduction(edge)
+    elseif ce > 1 && ceiniy == 1
+        #diagonal
+        any(ceinixs .> 1) && return MixedDiag{count(ceinixs .> 0)}(edge)
+        return Diag{ce}(edge)
+    elseif ce > 2 && ceiniy == 0
+        any(ceinixs .> 1) && return MixedStarContract{ce}(edge)
+        return StarContract{ce}(edge)
+    end
+end
+
+@doc raw"
+    modifyops(ixs, sxs, ops, iy)
+returns a list of operations with correct types.
+This is a quick fix while initial operation-assignment doesn't work,
+due to how the sequence of operations influences what operations are evaluated,
+e.g. a tensorcontraction might turn into a trace if the corresponding tensors
+are contracted earlier.
+This function just passes over all operations and returns a list of the 
+real operations that are evaluated.
+"
+function modifyops(ixs, sxs, ops, iy)
+    ops, = foldl(ops, init = (EinsumOp[], ixs, sxs)) do (nops, oixs, osxs), op
+        nop = operatorfromedge(op.edge, oixs, iy)
+        push!(nops,nop)
+        _ , nixs, nsxs = evaluatebutdont(op, 0, oixs, osxs)
+        (nops, nixs, nsxs)
+    end
+    return ops
+end
+
+
+function operatorsfrominds(ixs,iy)
+    edges = edgesfrominds(ixs,iy)
+    map(x -> operatorfromedge(x, ixs, iy), edges)
+end
+
+using TupleTools
+function indicesafterop(op::EinsumOp, ixs)
+    e = op.edge
+    Tuple(i for i in TupleTools.vcat(ixs...) if i != e)
+end
+
+function indicesafterop(op::Diag, ixs)
+    e = op.edge
+    (Tuple(i for i in TupleTools.vcat(ixs...) if i != e)...,e)
+end
+
+function indicesafterop(op::MixedDiag, ixs)
+    e = op.edge
+    (Tuple(i for i in TupleTools.vcat(ixs...) if i != e)...,e)
+end
+
+@doc raw"
+    evaluate(op::EinsumOp, allixs, allxs)
+returns a tuple of xs and a tuple of ixs that includes the result
+of the operation `op`.
+"
+function evaluate(op::EinsumOp, allixs, allxs)
+    e = op.edge
+    println("$op w/ einsum")
+    inds = Tuple(i for (i, ix) in enumerate(allixs) if e in ix)
+    ixs = TupleTools.getindices(allixs,inds)
+    xs  = TupleTools.getindices(allxs,inds)
+
+    nallixs =  TupleTools.deleteat(allixs, inds)
+    nallxs  =  TupleTools.deleteat(allxs,  inds)
+
+    nix = indicesafterop(op, ixs)
+    nx = einsum(ixs, xs, nix)
+
+    return (nix, nallixs...), (nx, nallxs...)
+end
+
+# overload evaluate for special types! multiple dispatch for separate functions!
+function evaluate(op::TensorContract, allixs, allxs)
+    println("$op w/ TensorOperations")
+    e = op.edge
+    inds = Tuple(i for (i, ix) in enumerate(allixs) if e in ix)
+    ixs = TupleTools.getindices(allixs,inds)
+    xs  = TupleTools.getindices(allxs,inds)
+
+    nallixs =  TupleTools.deleteat(allixs, inds)
+    nallxs  =  TupleTools.deleteat(allxs,  inds)
+
+    a, b = xs
+    ia, ib = ixs
+    i2change =  [i for (i,j) in enumerate(ia) if j in ib && j != e]
+    for i in i2change
+        ia = TupleTools.insertat(ia, i, (ia[i] + 1000,))
+    end
+    nix = indicesafterop(op, (ia,ib))
+    nx = tensorcontract(a,ia,b,ib,nix)
+    nix = map(x -> x > 500 ? x - 1000 : x, nix)
+
+    return (nix, nallixs...), (nx, nallxs...)
+end
+
+function evaluate(op::Trace, allixs, allxs)
+    println("Trace w/ TensorOperations")
+    e = op.edge
+    inds = Tuple(i for (i, ix) in enumerate(allixs) if e in ix)
+    ixs = TupleTools.getindices(allixs,inds)
+    xs  = TupleTools.getindices(allxs,inds)
+
+    nallixs =  TupleTools.deleteat(allixs, inds)
+    nallxs  =  TupleTools.deleteat(allxs,  inds)
+
+    a, = xs
+    ia, = ixs
+    nix = indicesafterop(op, (ia,))
+    nx = tensortrace(a,ia,nix)
+    return (nix, nallixs...), (nx, nallxs...)
+end
+
+@doc raw"
+    evaluatebutdont(op, ocost, allixs, allsxs)
+returns the cost (in number of iterations it would require in a for loop) 
+of evaluating `op` with arguments `allixs` and `allsxs` plus `ocost`
+as well as the new indices and sizes after evaluation.
+
+`allscs` is a tuple of tuples of Ints - the sizes of the respective arrays
+
+"
+function evaluatebutdont(op::EinsumOp, cost, allixs, allsxs::NTuple{M,NTuple{N,Int} where N} where M)
+    e = op.edge
+    inds = Tuple(i for (i, ix) in enumerate(allixs) if e in ix)
+    ixs = TupleTools.getindices(allixs,inds)
+    sxs  = TupleTools.getindices(allsxs,inds)
+    nix = indicesafterop(op, ixs)
+
+    nallixs =  TupleTools.deleteat(allixs, inds)
+    nallsxs  =  TupleTools.deleteat(allsxs,  inds)
+
+    allinds = reduce(vcat, collect.(ixs))
+    allsizes = reduce(vcat, collect.(sxs))
+    cost += mapreduce(*, unique(allinds)) do i
+        j = findfirst(==(i), allinds)
+        allsizes[j]
+    end
+    nsx = map(nix) do i
+        j = findfirst(==(i), allinds)
+        allsizes[j]
+    end
+    return (cost, (nix, nallixs...), (nsx, nallsxs...))
+end
+
+#ops = operatorsfrominds(ixs,iy)
+ixs = ((-1,-2,1), (-2,-3,2), (3,-3,-4), (4,-4,-1), (4,4,5), (1,6,7))
+iy = (6,2,3,5)
+ops = operatorsfrominds(ixs, iy)
+xs = map(i -> randn(map(j -> 2, i)), ixs)
+sxs = map(size,xs)
+
+
+@doc raw"
+    meinsumcost(ixs, xs, ops)
+returns the cost of evaluating the einsum of `ixs`, `xs` according to the
+sequence in ops.
+"
+function meinsumcost(ixs, xs, ops) 
+    foldl((args, op) -> evaluatebutdont(op, args...), ops, init = (0, ixs, xs))[1]
+end
+
+meinsum(ixs, xs, iy) = einsum(foldl(((ixs,xs), op) -> evaluate(op, ixs,xs),
+                                    operatorsfrominds(ixs, iy), init = (ixs,xs))..., iy)
+
+@doc raw"
+    meinsumopt(ixs, xs, iy)
+returns the result of the einsum operation implied by `ixs`, `iy` but
+evaluated in the optimal order according to `meinsumcost`.
+"
+function meinsumopt(ixs, xs, iy)
+    ops = operatorsfrominds(ixs, iy)
+    ops = optimiseorder(ixs, size.(xs), ops)[2]
+    ops = modifyops(ixs, size.(xs), ops, iy)
+    @show ops
+    res = foldl(((ixs, xs), op) -> evaluate(op, ixs, xs),
+                 ops, init = (ixs, xs))
+    return einsum(res...  ,iy)
+end
+
+using Combinatorics
+
+function optimiseorder(ixs, sxs, ops) 
+    foldl(permutations(ops), init = (typemax(Int), ops)) do (cost, op1), op2
+        ncost = meinsumcost(ixs, sxs, op2)
+        ncost < cost ? (ncost, op2) : (cost, op1)
+    end
+end

--- a/src/einorder.jl
+++ b/src/einorder.jl
@@ -15,52 +15,118 @@ end
 
 
 @doc raw"
-    EinsumOp
-abstract supertype of all einsum operations
+    EinsumOp{N}
+abstract supertype of all einsum operations involving N edges
 "
 abstract type EinsumOp{N} end
 
 (::Type{T})(i::S) where {T<:EinsumOp, S<:Union{Integer,AbstractChar}} = T((i,))
 
+@doc raw"
+    PlaceHolder
+subtype of EinsumOp that holds an edge. Is used as a placeholder for an operation
+before the operation is decided.
+"
 struct PlaceHolder{T} <: EinsumOp{1}
     edges::Tuple{T}
 end
 
+@doc raw"
+    TensorContract{N}
+is a type that represents a tensorcontraction of `N` edges
+which are stored in its `edges` field, e.g. `'ij,jk -> ik'`
+is represented by `TensorContract{1}((j,))`.
+"
 struct TensorContract{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
 
+@doc raw"
+    Trace{N}
+is a type that represents a trace operation of `N` edges,
+i.e. 2`N` indices, which are stored in its `edges` field,
+e.g. `'ijjk -> ik'` is represented by `Trace{1}((j,))`
+"
 struct Trace{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
 
+@doc raw"
+    StarContract{N}
+is a type that represents a star-contraction of `N` edges
+which are stored in its `edges` field.
+A `StarContract{N}` results from `N` tensors sharing at least one index
+but *no* tensor has duplicate shared indices, e.g. `'ij,ik,il -> jkl'`
+is represented by `StarContract{1}((i,))`.
+"
 struct StarContract{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
 
+@doc raw"
+    MixedStarContract{N}
+is a type that represents a mixed star-contraction of `N` edges
+which are stored in its `edges` field.
+A `MixedStarContract{N}` results from `N` tensors sharing at least one index
+and at least one tensor has duplicate shared indices, e.g. `'ij,ik,iil -> jkl'`
+is represented by `MixedStarContract{1}((i,))`.
+"
 struct MixedStarContract{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
 
+@doc raw"
+    Diag{N}
+is a type that represents a (generalized) diagonal of `N` edges
+of one tensor which are stored in its `edges` field, e.g. `'iij -> ij'` is
+represented by `Diag{1}((i,))`
+"
 struct Diag{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
 
+@doc raw"
+    MixedDiag{N}
+is a type that represents a (generalized) mixed diagonal of `N` edges
+of more than one tensor which are stored in its `edges` field,
+ e.g. `'iij, ik -> ijk'` is represented by `MixedDiag{1}((i,))`
+"
 struct MixedDiag{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
 
+@doc raw"
+    IndexReduction{N}
+is a type that represents an index reduction of `N` edges/indices
+which are stored in its `edges` field, e.g. `'ij -> i'` is
+represented by `IndexReduction{1}((j,))`.
+"
 struct IndexReduction{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
 
+@doc raw"
+    Permutation{N}
+is a type that represents a permutation of `N` indices
+which are stored in its `perm` field.
+"
 struct Permutation{N,T} <: EinsumOp{1}
     perm::NTuple{N,T}
 end
 
+@doc raw"
+    OuterProduct{N}
+is a type that represents an outer product of `N` tensors.
+"
 struct OuterProduct{N} <: EinsumOp{N}
 end
 
+@doc raw"
+    Fallback{N}
+is a type that represents an `einsum` resulting in `N` indices,
+which are stored in its `iy` field.
+It's used as a general fallback if no more efficient method is available.
+"
 struct Fallback{N,T} <: EinsumOp{N}
     iy::NTuple{N,T}
 end
@@ -194,7 +260,7 @@ returns the cost (in number of iterations it would require in a for loop)
 of evaluating `op` with arguments `allixs` and `allsxs` plus `ocost`
 as well as the new indices and sizes after evaluation.
 
-`allscs` is a tuple of tuples of Ints - the sizes of the respective arrays
+`allsxs` is a tuple of tuples of Ints - the sizes of the respective arrays
 
 "
 function opcost(op::EinsumOp, cost, allixs, allsxs::NTuple{M,NTuple{N,Int} where N} where M)
@@ -214,15 +280,13 @@ function opcost(op::EinsumOp, cost, allixs, allsxs::NTuple{M,NTuple{N,Int} where
                 ifelse(any(x -> allinds[x] == i, 1:(k-1)), 1, allsizes[k])
             end
     cost += prod(dims)
-    nsx = map(nix) do i
-        j = findfirst(==(i), allinds)::Int
-        allsizes[j]
-    end
+    nsx = map(i -> allsizes[findfirst(==(i), allinds)::Int], nix)
+
     return (cost, (nix, nallixs...), (nsx, nallsxs...))
 end
 
-function opcost(::Union{Fallback, OuterProduct, Permutation},
-    cost, allixs, allsxs::NTuple{M,NTuple{N,Int} where N} where M)
+function opcost(::Union{Fallback, OuterProduct, Permutation}, cost, allixs,
+     allsxs::NTuple{M,NTuple{N,Int} where N} where M)
      (0, (), ())
  end
 
@@ -230,9 +294,17 @@ function pickfromtup(things, inds)
     (TupleTools.getindices(things, inds), TupleTools.deleteat(things, inds))
 end
 
+@doc raw"
+    overlap(s1, s2)
+return true if `s1` and `s2` share any element.
+"
 overlap(s1, s2) = any(x -> x in s1, s2)
 
 
+@doc raw"
+    indicesafteroperation(op, allixs)
+returns all indices of tensors after operation `op` was applied.
+"
 function indicesafteroperation(op::EinsumOp, allixs)
     e = op.edges
     inds = Tuple(i for (i, ix) in enumerate(allixs) if overlap(ix,e))
@@ -275,7 +347,7 @@ function optimiseorder(ixs, sxs, ops,iy)
         op2p = modifyops(ixs,op2,iy)
         ncost = meinsumcost(ixs, sxs, op2p)
         if ncost == cost
-            #prefer less operations even if same cost
+            # if cost is the same, prefer less operations
             length(op2p) < length(op1) ? (ncost, op2p) : (cost, op1)
         else
             ncost < cost ? (ncost, op2p) : (cost, op1)

--- a/src/einorder.jl
+++ b/src/einorder.jl
@@ -7,7 +7,7 @@ in ixs = ((1,2),(2,3)), iy = (1,3), edge 2
 requires a tensor contraction
 "
 function edgesfrominds(ixs,iy)
-    allixs = TupleTools.flatten(ixs)
+    allixs = TupleTools.vcat(ixs...)
     pred(i,e) = !(count(==(e), allixs) == 1 && e in iy) && # not trivial
                 all(j -> allixs[j] != e, 1:(i-1)) # not seen before
     Tuple(e for (i,e) in enumerate(allixs) if pred(i,e))
@@ -80,7 +80,7 @@ corresponds to.
 function operatorfromedge(edge, ixs, iy)
     #it would be nice if this could be user extendible, maybe traits?
     edge == () &&  ArgumentError("empty edge provided")
-    allixs = TupleTools.flatten(ixs)
+    allixs = TupleTools.vcat(ixs...)
     ce      = count(==(edge), allixs)
     ceiniy  = count(==(edge), iy)
     ceinixs = count.(==(edge), ixs)
@@ -176,15 +176,15 @@ end
 
 function indicesafterop(op::EinsumOp, ixs)
     e = op.edges
-    Tuple(i for i in TupleTools.flatten(ixs) if i ∉ e)
+    Tuple(i for i in TupleTools.vcat(ixs...) if i ∉ e)
 end
 
 function indicesafterop(op::Union{MixedDiag,Diag}, ixs)
     e = op.edges
-    (Tuple(i for i in TupleTools.flatten(ixs) if i ∉ e)...,e...)
+    (Tuple(i for i in TupleTools.vcat(ixs...) if i ∉ e)...,e...)
 end
 
-indicesafterop(op::OuterProduct{N}, ixs) where N = TupleTools.flatten(ixs)
+indicesafterop(op::OuterProduct{N}, ixs) where N = TupleTools.vcat(ixs...)
 indicesafterop(op::Permutation, ixs) = TupleTools.permute(ixs, op.perm)
 
 @doc raw"
@@ -205,8 +205,8 @@ function opcost(op::EinsumOp, cost, allixs, allsxs::NTuple{M,NTuple{N,Int} where
 
     nix = indicesafterop(op, ixs)
 
-    allinds  = TupleTools.flatten(ixs)
-    allsizes = TupleTools.flatten(sxs)
+    allinds  = TupleTools.vcat(ixs...)
+    allsizes = TupleTools.vcat(sxs...)
 
     l = length(allinds)
     dims = map(ntuple(identity,l), allinds) do k,i
@@ -235,7 +235,7 @@ function indicesafteroperation(op::EinsumOp, allixs)
     return (nix, nallixs...)
 end
 
-indicesafteroperation(op::OuterProduct{N}, allixs) where N = (TupleTools.flatten(allixs),)
+indicesafteroperation(op::OuterProduct{N}, allixs) where N = (TupleTools.vcat(allixs...),)
 
 
 @doc raw"

--- a/src/einorder.jl
+++ b/src/einorder.jl
@@ -105,13 +105,16 @@ operatorfromedge(op::EinsumOp{1}, ixs, iy) = operatorfromedge(op.edges[1], ixs, 
 return `true` if `EinsumOp`s `a` and `b` can be combined into one operator.
 "
 iscombineable(::Any,::Any) = false
-iscombineable(::T, ::T) where {T <: EinsumOp} = true
+iscombineable(::T, ::S) where {T <: EinsumOp, S <: EinsumOp} = T.name == S.name
 
 @doc raw"
     combineops(op1, op2)
 return an operator that combines the operations of `op1` and `op2`.
 "
-combineops(op1::T, op2::T) where {T <: EinsumOp} = T.name.wrapper((op1.edges..., op2.edges...))
+function combineops(op1::T, op2::S) where {T <: EinsumOp, S <: EinsumOp}
+    T.name == S.name && return T.name.wrapper((op1.edges..., op2.edges...))
+    error()
+end
 
 
 

--- a/src/einorder.jl
+++ b/src/einorder.jl
@@ -112,7 +112,6 @@ iscombineable(::T, ::T) where {T <: EinsumOp} = true
 return an operator that combines the operations of `op1` and `op2`.
 "
 combineops(op1::T, op2::T) where {T <: EinsumOp} = T.name.wrapper((op1.edges..., op2.edges...))
-combineops(::Any,::Any) = false
 
 
 

--- a/src/einorder.jl
+++ b/src/einorder.jl
@@ -104,7 +104,6 @@ operatorfromedge(op::EinsumOp{1}, ixs, iy) = operatorfromedge(op.edges[1], ixs, 
     iscombineable(a,b)
 return `true` if `EinsumOp`s `a` and `b` can be combined into one operator.
 "
-iscombineable(::Any,::Any) = false
 iscombineable(::T, ::S) where {T <: EinsumOp, S <: EinsumOp} = T.name == S.name
 
 @doc raw"
@@ -113,7 +112,7 @@ return an operator that combines the operations of `op1` and `op2`.
 "
 function combineops(op1::T, op2::S) where {T <: EinsumOp, S <: EinsumOp}
     T.name == S.name && return T.name.wrapper((op1.edges..., op2.edges...))
-    error()
+    throw(ArgumentError("Can not combine $op1 and $op2"))
 end
 
 
@@ -222,8 +221,10 @@ function opcost(op::EinsumOp, cost, allixs, allsxs::NTuple{M,NTuple{N,Int} where
     return (cost, (nix, nallixs...), (nsx, nallsxs...))
 end
 
-opcost(::Union{Fallback, OuterProduct, Permutation},
-    cost, allixs, allsxs::NTuple{M,NTuple{N,Int} where N} where M) = (0, (), ())
+function opcost(::Union{Fallback, OuterProduct, Permutation},
+    cost, allixs, allsxs::NTuple{M,NTuple{N,Int} where N} where M)
+     (0, (), ())
+ end
 
 function pickfromtup(things, inds)
     (TupleTools.getindices(things, inds), TupleTools.deleteat(things, inds))

--- a/src/einorder.jl
+++ b/src/einorder.jl
@@ -16,7 +16,8 @@ end
 
 @doc raw"
     EinsumOp{N}
-abstract supertype of all einsum operations involving N edges
+abstract supertype of all einsum operations involving `N` edges
+or `N` tensors (for `OuterProduct{N}`).
 "
 abstract type EinsumOp{N} end
 
@@ -30,54 +31,52 @@ before the operation is decided.
 struct PlaceHolder{T} <: EinsumOp{1}
     edges::Tuple{T}
 end
-
-@doc raw"
-    TensorContract{N}
+    TensorContract{N,T}
 is a type that represents a tensorcontraction of `N` edges
-which are stored in its `edges` field, e.g. `'ij,jk -> ik'`
-is represented by `TensorContract{1}((j,))`.
+of type `T` which are stored in its `edges` field, e.g. `'ij,jk -> ik'`
+is represented by `TensorContract{1,Char}((j,))`.
 "
 struct TensorContract{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
 
 @doc raw"
-    Trace{N}
-is a type that represents a trace operation of `N` edges,
-i.e. 2`N` indices, which are stored in its `edges` field,
-e.g. `'ijjk -> ik'` is represented by `Trace{1}((j,))`
+    Trace{N,T}
+is a type that represents a trace operation of `N` edges
+of type `T`, i.e. 2`N` indices, which are stored in its `edges` field,
+e.g. `'ijjk -> ik'` is represented by `Trace{1,Char}((j,))`
 "
 struct Trace{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
 
 @doc raw"
-    StarContract{N}
-is a type that represents a star-contraction of `N` edges
+    StarContract{N,T}
+is a type that represents a star-contraction of `N` edges of type `T`
 which are stored in its `edges` field.
 A `StarContract{N}` results from `N` tensors sharing at least one index
 but *no* tensor has duplicate shared indices, e.g. `'ij,ik,il -> jkl'`
-is represented by `StarContract{1}((i,))`.
+is represented by `StarContract{1,Char}((i,))`.
 "
 struct StarContract{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
 
 @doc raw"
-    MixedStarContract{N}
-is a type that represents a mixed star-contraction of `N` edges
+    MixedStarContract{N,T}
+is a type that represents a mixed star-contraction of `N` edges of type `T`
 which are stored in its `edges` field.
 A `MixedStarContract{N}` results from `N` tensors sharing at least one index
 and at least one tensor has duplicate shared indices, e.g. `'ij,ik,iil -> jkl'`
-is represented by `MixedStarContract{1}((i,))`.
+is represented by `MixedStarContract{1,Char}((i,))`.
 "
 struct MixedStarContract{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
 
 @doc raw"
-    Diag{N}
-is a type that represents a (generalized) diagonal of `N` edges
+    Diag{N,T}
+is a type that represents a (generalized) diagonal of `N` edges of type `T`
 of one tensor which are stored in its `edges` field, e.g. `'iij -> ij'` is
 represented by `Diag{1}((i,))`
 "
@@ -86,29 +85,30 @@ struct Diag{N,T} <: EinsumOp{N}
 end
 
 @doc raw"
-    MixedDiag{N}
+    MixedDiag{N,T}
 is a type that represents a (generalized) mixed diagonal of `N` edges
-of more than one tensor which are stored in its `edges` field,
- e.g. `'iij, ik -> ijk'` is represented by `MixedDiag{1}((i,))`
+of type `T` of more than one tensor which are stored in its `edges` field,
+ e.g. `'iij, ik -> ijk'` is represented by `MixedDiag{1,Char}((i,))`
 "
 struct MixedDiag{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
 
 @doc raw"
-    IndexReduction{N}
-is a type that represents an index reduction of `N` edges/indices
+    IndexReduction{N,T}
+is a type that represents an index reduction of `N` edges/indices of type `T`
 which are stored in its `edges` field, e.g. `'ij -> i'` is
-represented by `IndexReduction{1}((j,))`.
+represented by `IndexReduction{1,Char}((j,))`.
 "
 struct IndexReduction{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
 
 @doc raw"
-    Permutation{N}
+    Permutation{N,T}
 is a type that represents a permutation of `N` indices
-which are stored in its `perm` field.
+which are stored in its `perm` field as a tuple of
+`N` integers of type `T`.
 "
 struct Permutation{N,T} <: EinsumOp{1}
     perm::NTuple{N,T}
@@ -122,8 +122,8 @@ struct OuterProduct{N} <: EinsumOp{N}
 end
 
 @doc raw"
-    Fallback{N}
-is a type that represents an `einsum` resulting in `N` indices,
+    Fallback{N,T}
+is a type that represents an `einsum` resulting in `N` indices of type `T`,
 which are stored in its `iy` field.
 It's used as a general fallback if no more efficient method is available.
 "

--- a/src/einorder.jl
+++ b/src/einorder.jl
@@ -1,19 +1,4 @@
-using OMEinsum
-using TensorOperations
-#= einorder
-1) identify edges & their corresponding operations:
-    - tensorcontraction
-    - (partial) trace
-    - (partial) diagonal
-    - star-contraction between
-    - star-contraction mixed
-    - index reduction
-    - perm
-   and then construct list of all operations implied by the indices
-2. optimise order of operations for minimum total iterations (in the naive loop view)
-
-3. evaluate einsum in optimized order
-=#
+using TensorOperations, TupleTools, Combinatorics
 
 @doc raw"
     edgesfrominds(ixs,iy)
@@ -22,7 +7,7 @@ in ixs = ((1,2),(2,3)), iy = (1,3), edge 2
 requires a tensor contraction
 "
 function edgesfrominds(ixs,iy)
-    allixs = TupleTools.vcat(ixs...)
+    allixs = TupleTools.flatten(ixs)
     pred(i,e) = !(count(==(e), allixs) == 1 && e in iy) && # not trivial
                 all(j -> allixs[j] != e, 1:(i-1)) # not seen before
     Tuple(e for (i,e) in enumerate(allixs) if pred(i,e))
@@ -35,63 +20,58 @@ abstract supertype of all einsum operations
 "
 abstract type EinsumOp{N} end
 
-struct PlaceHolder{T} <: EinsumOp{0}
-    edge::T
-    keep::Bool
+(::Type{T})(i::S) where {T<:EinsumOp, S<:Union{Integer,AbstractChar}} = T((i,))
+
+struct PlaceHolder{T} <: EinsumOp{1}
+    edges::Tuple{T}
 end
 
 struct TensorContract{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
-TensorContract(e::Int) = TensorContract((e,))
 
 struct Trace{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
-Trace(e::Int) = Trace((e,))
 
 struct StarContract{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
-StarContract(e::Int) = StarContract((e,))
 
 struct MixedStarContract{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
-MixedStarContract(e::Int) = MixedStarContract((e,))
 
 struct Diag{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
-Diag(e::Int) = Diag((e,))
 
 struct MixedDiag{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
-MixedDiag(e::Int) = MixedDiag((e,))
 
 struct IndexReduction{N,T} <: EinsumOp{N}
     edges::NTuple{N,T}
 end
-IndexReduction(e::Int) = IndexReduction((e,))
 
-placeholderfromedge(edge, iy) = PlaceHolder(edge, edge in iy)
-function placeholdersfrominds(ixs, iy)
-    edges = edgesfrominds(ixs,iy)
-    map(x -> placeholderfromedge(x, iy), edges)
-end
+@doc raw"
+    placeholdersfrominds(ixs, iy)
+return all indices in `ixs` that imply an operation, wrapped in a `PlaceHolder`.
+"
+placeholdersfrominds(ixs, iy) = map(PlaceHolder, edgesfrominds(ixs, iy))
 
 @doc raw"
     operatorfromedge(edge, ixs, iy)
 returns a subtype of `EinsumOp` which specifies
-the kind of operation that `edge` implies.
+the kind of operation that the reduction of `edge`
+corresponds to.
 "
 function operatorfromedge(edge, ixs, iy)
     #it would be nice if this could be user extendible, maybe traits?
-    edge == () &&  error()
-    allixs = TupleTools.vcat(ixs...)
-    ce = count(==(edge), allixs)
-    ceiniy = count(==(edge), iy)
+    edge == () &&  ArgumentError("empty edge provided")
+    allixs = TupleTools.flatten(ixs)
+    ce      = count(==(edge), allixs)
+    ceiniy  = count(==(edge), iy)
     ceinixs = count.(==(edge), ixs)
     if ce == 2 && ceiniy == 0
         all(x -> x == 0 || x == 1, ceinixs) && return TensorContract(edge)
@@ -99,8 +79,7 @@ function operatorfromedge(edge, ixs, iy)
     elseif  ce == 1 && ceiniy == 0
         return IndexReduction(edge)
     elseif ce > 1 && ceiniy >= 1
-        #diagonal
-        count(x -> x > 1, ceinixs) > 1 && return MixedDiag(edge)
+        any(x -> x > 1, ceinixs) && return MixedDiag(edge)
         return Diag(edge)
     elseif ce > 2 && ceiniy == 0
         any(x -> x > 1, ceinixs) && return MixedStarContract(edge)
@@ -108,182 +87,70 @@ function operatorfromedge(edge, ixs, iy)
     end
 end
 
+operatorfromedge(op::EinsumOp{1}, ixs, iy) = operatorfromedge(op.edges[1], ixs, iy)
+
+@doc raw"
+    iscombineable(a,b)
+return `true` if `EinsumOp`s `a` and `b` can be combined into one operator.
+"
+iscombineable(::Any,::Any) = false
+iscombineable(::T, ::T) where {T <: EinsumOp} = true
+
+@doc raw"
+    combineops(op1, op2)
+return an operator that combines the operations of `op1` and `op2`.
+"
+combineops(op1::T, op2::T) where {T <: EinsumOp} = T.name.wrapper((op1.edges..., op2.edges...))
+combineops(::Any,::Any) = false
+
+
+
 @doc raw"
     modifyops(ixs, sxs, ops, iy)
-returns a list of operations with correct types.
-This is a quick fix while initial operation-assignment doesn't work,
-due to how the sequence of operations influences what operations are evaluated,
-e.g. a tensorcontraction might turn into a trace if the corresponding tensors
-are contracted earlier.
-This function just passes over all operations and returns a list of the
-real operations that are evaluated.
+given a list of placeholders `ops`, return a list of operations where
+consecutive operations are combined if possible.
 "
-iscompatible(::EinsumOp, ::EinsumOp) = false
-iscompatible(::TensorContract, ::TensorContract) = true
-iscompatible(::Trace, ::Trace) = true
-iscompatible(::MixedDiag, ::MixedDiag) = true
-iscompatible(::IndexReduction, ::IndexReduction) = true
-iscompatible(::Diag, ::Diag) = true
+function modifyops(ixs, ops, iy)
+    ops == () && return ()
+    opi = operatorfromedge(first(ops), ixs, iy)
+    ops, _, op, = foldl((x,z) -> _modifyhelper(x,z,iy),
+                        ops[2:end],
+                        init = ((), ixs, opi, supportinds(opi, ixs)))
+    return (ops..., op)
+end
 
-function foo((ops, ixs, op2, sop2), op, iy)
+function _modifyhelper((ops, ixs, op2, sop2), op, iy)
     sop1 = supportinds(op, ixs)
-    op1 = operatorfromedge(op.edge, ixs, iy)
+    op1  = operatorfromedge(op, ixs, iy)
 
-    if iscompatible(op1,op2) && sop1 == sop2
-        #if compatible and same support - keep and go on
+    if iscombineable(op1,op2) && sop1 == sop2
         nop = combineops(op1, op2)
         return (ops, ixs, nop, sop2)
     else
         nixs = indicesafteroperation(op2, ixs)
+        op1  = operatorfromedge(op1, nixs, iy)
         sop1 = supportinds(op1, nixs)
         return ((ops..., op2), nixs, op1, sop1)
     end
 end
 
-combineops(op1::TensorContract, op2::TensorContract) =
-    TensorContract((op1.edges...,op2.edges...))
-combineops(op1::Trace, op2::Trace) =
-    Trace((op1.edges...,op2.edges...))
-combineops(op1::IndexReduction, op2::IndexReduction) =
-    IndexReduction((op1.edges...,op2.edges...))
-combineops(op1::Diag, op2::Diag) =
-    Diag((op1.edges...,op2.edges...))
-
-function modifyops(ixs, ops, iy)
-    ops == () && return ()
-    opi = operatorfromedge(ops[1].edge, ixs, iy)
-    ops, nixs, op, = foldl((x,z) -> foo(x,z,iy),
-                        ops[2:end],
-                        init = ((), ixs, opi, supportinds(opi, ixs)))
-    length(op.edges) == 1 && (op = operatorfromedge(op.edges[1], nixs, iy))
-    return (ops..., op)
-end
-
 supportinds(op, ixs) = Tuple(i for (i,ix) in enumerate(ixs) if op.edges[1] in ix)
-supportinds(op::PlaceHolder, ixs) = Tuple(i for (i,ix) in enumerate(ixs) if op.edge[1] in ix)
 
-
-
-
-#in reality, outer products between all tensors should be included as ops
-function operatorsfrominds(ixs,iy)
-    edges = edgesfrominds(ixs,iy)
-    map(x -> operatorfromedge(x, ixs, iy), edges)
+function opsfrominds(ixs, iy)
+    tmp = placeholdersfrominds(ixs, iy)
+    tmp = TupleTools.sort(tmp, by = x -> x.edges[1])
+    return modifyops(ixs, tmp, iy)
 end
 
-using TupleTools
-function indicesafterop(op::PlaceHolder, ixs)
-    e = op.edge
-    Tuple(i for i in TupleTools.vcat(ixs...) if i != e)
-end
 function indicesafterop(op::EinsumOp, ixs)
     e = op.edges
-    Tuple(i for i in TupleTools.vcat(ixs...) if i ∉ e)
+    Tuple(i for i in TupleTools.flatten(ixs) if i ∉ e)
 end
 
-function indicesafterop(op::Diag, ixs)
+function indicesafterop(op::Union{MixedDiag,Diag}, ixs)
     e = op.edges
-    (Tuple(i for i in TupleTools.vcat(ixs...) if i ∉ e)...,e...)
+    (Tuple(i for i in TupleTools.flatten(ixs) if i ∉ e)...,e...)
 end
-
-function indicesafterop(op::MixedDiag, ixs)
-    e = op.edges
-    (Tuple(i for i in TupleTools.vcat(ixs...) if i ∉ e)...,e...)
-end
-
-@doc raw"
-    evaluate(op::EinsumOp, allixs, allxs)
-returns a tuple of xs and a tuple of ixs that includes the result
-of the operation `op`.
-"
-function evaluate(op::EinsumOp, allixs, allxs)
-    e = op.edges
-    # println("$op w/ einsum")
-    inds = Tuple(i for (i, ix) in enumerate(allixs) if !isempty(intersect(e,ix)))
-    ixs = TupleTools.getindices(allixs,inds)
-    xs  = TupleTools.getindices(allxs,inds)
-
-    nallixs =  TupleTools.deleteat(allixs, inds)
-    nallxs  =  TupleTools.deleteat(allxs,  inds)
-
-    nix = indicesafterop(op, ixs)
-    nx = einsumexp(ixs, xs, nix)
-
-    return (nix, nallixs...), (nx, nallxs...)
-end
-
-function evaluate(op::IndexReduction, allixs, allxs)
-    e = op.edges[1]
-    # println("$op w/ sum")
-    ind = findfirst(x -> e in x, allixs)
-    ix, x = allixs[ind], allxs[ind]
-
-    nallixs =  TupleTools.deleteat(allixs, (ind,))
-    nallxs  =  TupleTools.deleteat(allxs,  (ind,))
-
-    inds = Tuple(findall(x -> x in op.edges, ix))
-    nix = TupleTools.deleteat(ix, inds)
-    nx = dropdims(sum(x, dims = inds), dims = inds)
-
-    return (nallixs..., nix), (nallxs..., nx)
-end
-
-# # overload evaluate for special types! multiple dispatch for separate functions!
-# function evaluate(op::TensorContract, allixs, allxs)
-#     # println("$op w/ TensorOperations")
-#     e = op.edge
-#     inds = Tuple(i for (i, ix) in enumerate(allixs) if e in ix)
-#     ixs = TupleTools.getindices(allixs,inds)
-#     xs  = TupleTools.getindices(allxs,inds)
-#
-#     nallixs =  TupleTools.deleteat(allixs, inds)
-#     nallxs  =  TupleTools.deleteat(allxs,  inds)
-#
-#     a, b = xs
-#     ia, ib = ixs
-#     i2change =  [i for (i,j) in enumerate(ia) if j in ib && j != e]
-#     for i in i2change
-#         ia = TupleTools.insertat(ia, i, (ia[i] + 1000,))
-#     end
-#     nix = indicesafterop(op, (ia,ib))
-#     nx = tensorcontract(a,ia,b,ib,nix)
-#     nix = map(x -> x > 500 ? x - 1000 : x, nix)
-#
-#     return (nix, nallixs...), (nx, nallxs...)
-# end
-#
-# function evaluate(op::Trace, allixs, allxs)
-#     # println("Trace w/ TensorOperations")
-#     e = op.edge
-#     inds = Tuple(i for (i, ix) in enumerate(allixs) if e in ix)
-#     ixs = TupleTools.getindices(allixs,inds)
-#     xs  = TupleTools.getindices(allxs,inds)
-#
-#     nallixs =  TupleTools.deleteat(allixs, inds)
-#     nallxs  =  TupleTools.deleteat(allxs,  inds)
-#
-#     a, = xs
-#     ia, = ixs
-#     i2change =  [i for (i,j) in enumerate(ia) if count(==(j),ia) > 1 && j != e]
-#     c = 1
-#     for i in i2change
-#         ia = TupleTools.insertat(ia, i, (ia[i] + 1000+c,))
-#         c += 1
-#     end
-#     nix = indicesafterop(op, (ia,))
-#     nx = tensortrace(a,ia,nix)
-#     c = 1
-#     for i in 1:length(nix)
-#         if nix[i] > 500
-#             nix = TupleTools.insertat(nix, i, (nix[i] - 1000-c,))
-#             c += 1
-#         end
-#     end
-#     return (nix, nallixs...), (nx, nallxs...)
-# end
-
-
-#Optimiziation
 
 @doc raw"
     opcost(op, ocost, allixs, allsxs)
@@ -297,19 +164,20 @@ as well as the new indices and sizes after evaluation.
 function opcost(op::EinsumOp, cost, allixs, allsxs::NTuple{M,NTuple{N,Int} where N} where M)
     e = op.edges
     inds = Tuple(i for (i, ix) in enumerate(allixs) if !isempty(intersect(e,ix)))
-    ixs = TupleTools.getindices(allixs,inds)
-    sxs = TupleTools.getindices(allsxs,inds)
+
+    ixs, nallixs = pickfromtup(allixs, inds)
+    sxs, nallsxs = pickfromtup(allsxs, inds)
+
     nix = indicesafterop(op, ixs)
 
-    nallixs = TupleTools.deleteat(allixs, inds)
-    nallsxs = TupleTools.deleteat(allsxs,  inds)
+    allinds  = TupleTools.flatten(ixs)
+    allsizes = TupleTools.flatten(sxs)
 
-    allinds  = TupleTools.vcat(ixs...)
-    allsizes = TupleTools.vcat(sxs...)
-
-    cost += prod(map(ntuple(i -> (i, allinds[i]), length(allinds))) do (k,i)
-        ifelse(any(x -> allinds[x] == i, 1:(k-1)), 1, allsizes[k])
-    end)
+    l = length(allinds)
+    dims = map(ntuple(identity,l), allinds) do k,i
+                ifelse(any(x -> allinds[x] == i, 1:(k-1)), 1, allsizes[k])
+            end
+    cost += prod(dims)
     nsx = map(nix) do i
         j = findfirst(==(i), allinds)::Int
         allsizes[j]
@@ -317,12 +185,15 @@ function opcost(op::EinsumOp, cost, allixs, allsxs::NTuple{M,NTuple{N,Int} where
     return (cost, (nix, nallixs...), (nsx, nallsxs...))
 end
 
+function pickfromtup(things, inds)
+    (TupleTools.getindices(things, inds), TupleTools.deleteat(things, inds))
+end
+
 function indicesafteroperation(op::EinsumOp, allixs)
     e = op.edges
     inds = Tuple(i for (i, ix) in enumerate(allixs) if !isempty(intersect(ix, e)))
-    ixs = TupleTools.getindices(allixs,inds)
+    ixs, nallixs = pickfromtup(allixs, inds)
     nix = indicesafterop(op, ixs)
-    nallixs = TupleTools.deleteat(allixs, inds)
     return (nix, nallixs...)
 end
 
@@ -335,18 +206,29 @@ function meinsumcost(ixs, xs, ops)
     foldl((args, op) -> opcost(op, args...), ops, init = (0, ixs, xs))[1]
 end
 
+@doc raw"
+    optimalorder(ixs, xs, iy)
+return a tuple of operations that represents the (possibly nonunique) optimal
+order of reduction-operations.
+"
+function optimalorder(ixs, xs, iy)
+    tmp = placeholdersfrominds(ixs, iy)
+    sxs = size.(xs)
+    optimiseorder(ixs, sxs, tmp, iy)[2]
+end
 
-
-using Combinatorics
-
+@doc raw"
+    optimiseorder(ixs, sxs, ops, iy)
+return a tuple of operations that represents the (possibly nonunique) optimal
+order of reduction-operations in `ops` and its cost.
+"
 function optimiseorder(ixs, sxs, ops,iy)
     isempty(ops) && return (0, ())
     foldl(permutations(ops), init = (typemax(Int), modifyops(ixs,ops,iy))) do (cost, op1), op2
         op2p = modifyops(ixs,op2,iy)
         ncost = meinsumcost(ixs, sxs, op2p)
         if ncost == cost
-            @show  op2p, op1
-            @show cost
+            #prefer less operations even if same cost
             length(op2p) < length(op1) ? (ncost, op2p) : (cost, op1)
         else
             ncost < cost ? (ncost, op2p) : (cost, op1)

--- a/src/einorder.jl
+++ b/src/einorder.jl
@@ -287,7 +287,7 @@ end
 
 function opcost(::Union{Fallback, OuterProduct, Permutation}, cost, allixs,
      allsxs::NTuple{M,NTuple{N,Int} where N} where M)
-     (0, (), ())
+     (cost, (), ())
  end
 
 function pickfromtup(things, inds)

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -2,7 +2,7 @@ using TupleTools, Base.Cartesian
 
 function outindsfrominput(ixs)
     allixs = vcat(collect.(ixs)...)
-    iy = sort!(filter(x -> count(==(x), allixs) == 1, allixs))
+    iy = sort!(filter!(x -> count(==(x), TupleTools.vcat(ixs...)) == 1, allixs))
     return tuple(iy...)
 end
 

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -40,6 +40,11 @@ function einsum(ixs, xs, iy)
     einsumexp(foldl(((ixs,xs), op) -> evaluate(op, ixs,xs), ops, init = (ixs,xs))..., iy)
 end
 
+function einsumopt(cs, ts)
+    allins  = reduce(vcat, collect.(cs))
+    outinds = sort(filter(x -> count(==(x), allins) == 1, allins))
+    einsumopt(cs, ts, tuple(outinds...))
+end
 @doc raw"
     meinsumopt(ixs, xs, iy)
 returns the result of the einsum operation implied by `ixs`, `iy` but
@@ -49,7 +54,6 @@ function einsumopt(ixs, xs, iy)
     ops = operatorsfrominds(ixs, iy)
     ops = optimiseorder(ixs, size.(xs), ops)[2]
     ops = modifyops(ixs, size.(xs), ops, iy)
-    @show ops
     res = foldl(((ixs, xs), op) -> evaluate(op, ixs, xs),
                  ops, init = (ixs, xs))
     return einsumexp(res...  ,iy)

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -9,7 +9,9 @@ end
 @doc raw"
     einsum(cs, ts, out)
 return the tensor that results from contracting the tensors `ts` according
-to their indices `cs`, where twice-appearing indices are contracted.
+to their indices `cs`, where all indices that do not appear in the output are
+summed over. The indices are contracted in the order implied by their numerical value,
+smaller first.
 The result is permuted according to `out`.
 
 - `cs` - tuple of tuple of integers that label all indices of a tensor.
@@ -19,7 +21,6 @@ The result is permuted according to `out`.
 
 - `out` - tuple of integers that should correspond to remaining indices in `cs` after contractions.
 
-This implementation has space requirements that are exponential in the number of unique indices.
 
 # example
 ```jldoctest; setup = :(using OMEinsum)
@@ -36,6 +37,7 @@ true
 "
 function einsum(ixs, xs, iy)
     opstmp = placeholdersfrominds(ixs, iy)
+    opstmp = TupleTools.sort(opstmp, by = x -> x.edge)
     ops = modifyops(ixs, opstmp, iy)
     res = foldl(((ixs,xs), op) -> evaluate(op, ixs,xs), ops, init = (ixs,xs))
     einsumexp(res..., iy)

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -70,10 +70,10 @@ function outputtensor(xs, ixs, iy)
 end
 
 
-function einsumexp!(ixs::NTuple{N, NTuple{M, Union{AbstractChar,Int}} where M},
+function einsumexp!(ixs::NTuple{N, NTuple{M, IT} where M},
                 xs::NTuple{N, AbstractArray{<:Any,M} where M},
-                iy::NTuple{L,Union{AbstractChar,Int}},
-                y::AbstractArray{T,L}) where {N,L,T}
+                iy::NTuple{L,IT},
+                y::AbstractArray{T,L}) where {N,L,T,IT <: Union{AbstractChar,Integer}}
     all_indices = TupleTools.vcat(ixs..., iy)
     indices = unique(all_indices)
     size_dict = get_size_dict((ixs..., iy), (xs..., y))
@@ -102,9 +102,9 @@ end
 index_map(ind::CartesianIndex, locs::Tuple) = CartesianIndex(TupleTools.getindices(Tuple(ind), locs))
 
 """get the dictionary of `index=>size`, error if there are conflicts"""
-function get_size_dict(ixs, xs)
+function get_size_dict(ixs::NTuple{N, NTuple{M, T} where M} where N, xs) where T
     nt = length(ixs)
-    size_dict = Dict{Union{AbstractChar,Int}, Int}()
+    size_dict = Dict{T,Int}()
     @inbounds for i = 1:nt
         for (N, leg) in zip(size(xs[i]), ixs[i])
             if haskey(size_dict, leg)

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -53,11 +53,11 @@ evaluated in the optimal order according to `meinsumcost`.
 "
 function einsumopt(ixs, xs, iy)
     opstmp = placeholdersfrominds(ixs, iy)
-    ops = optimiseorder(ixs, size.(xs), opstmp)[2]
-    ops = modifyops(ixs, opstmp, iy)
+    ops = optimiseorder(ixs, size.(xs), opstmp, iy)[2]
     res = foldl(((ixs, xs), op) -> evaluate(op, ixs, xs), ops, init = (ixs, xs))
     return einsumexp(res...  ,iy)
 end
+
 function einsumexp(contractions::NTuple{N, NTuple{M, T} where M},
                 tensors::NTuple{N, AbstractArray{<:Any,M} where M},
                 outinds::NTuple{<:Any,T}) where {N,T}

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -35,9 +35,10 @@ true
 ```
 "
 function einsum(ixs, xs, iy)
-    ops = operatorsfrominds(ixs, iy)
-    ops = modifyops(ixs, size.(xs), ops, iy)
-    einsumexp(foldl(((ixs,xs), op) -> evaluate(op, ixs,xs), ops, init = (ixs,xs))..., iy)
+    opstmp = placeholdersfrominds(ixs, iy)
+    ops = modifyops(ixs, opstmp, iy)
+    res = foldl(((ixs,xs), op) -> evaluate(op, ixs,xs), ops, init = (ixs,xs))
+    einsumexp(res..., iy)
 end
 
 function einsumopt(cs, ts)
@@ -51,11 +52,10 @@ returns the result of the einsum operation implied by `ixs`, `iy` but
 evaluated in the optimal order according to `meinsumcost`.
 "
 function einsumopt(ixs, xs, iy)
-    ops = operatorsfrominds(ixs, iy)
-    ops = optimiseorder(ixs, size.(xs), ops)[2]
-    ops = modifyops(ixs, size.(xs), ops, iy)
-    res = foldl(((ixs, xs), op) -> evaluate(op, ixs, xs),
-                 ops, init = (ixs, xs))
+    opstmp = placeholdersfrominds(ixs, iy)
+    ops = optimiseorder(ixs, size.(xs), opstmp)[2]
+    ops = modifyops(ixs, opstmp, iy)
+    res = foldl(((ixs, xs), op) -> evaluate(op, ixs, xs), ops, init = (ixs, xs))
     return einsumexp(res...  ,iy)
 end
 function einsumexp(contractions::NTuple{N, NTuple{M, T} where M},

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -1,62 +1,7 @@
 using Test
-using OMEinsum: bpcheck, einsum!
+using OMEinsum: bpcheck
 using OMEinsum
 using Zygote
-
-@testset "einsum! bp" begin
-    for T in (Float64, ComplexF64)
-        @testset "$T" begin
-            # matrix and vector multiplication
-            a,b,c = rand(T,2,2), rand(T,2,2), rand(T,2,2)
-            v = rand(T,2)
-            t = randn(2,2,2,2)
-            @test bpcheck( (a,b,c) -> einsum!(((1,2),(2,3),(3,4)), (a,b,c), (1,4), zeros(T,2,2)) |> abs ∘ sum ,a,b,c)
-
-            @test bpcheck( (a,b,c) -> einsum!(((1,2),(2,3),(3,4)), (a,b,c), (4,1), zeros(T,2,2)) |> abs ∘ sum ,a,b,c)
-
-            @test bpcheck((a,v) -> einsum!(((1,2),(2,)), (a,v), (1,), zeros(T,2)) |> abs ∘ sum , a, v)
-
-            # contract to 0-dim array
-            @test bpcheck((a,b) -> einsum!(((1,2),(1,2)), (a,b), (), zeros(T)) |> abs ∘ sum , a,b)
-
-            # trace
-            @test bpcheck(a -> einsum!(((1,1),), (a,), (), zeros(T)) |> abs ∘ sum, a)
-            aa = rand(T,2,4,4,2)
-            @test bpcheck(aa -> einsum!(((1,2,2,1),), (aa,), (), zeros(T)) |> abs ∘ sum, aa)
-
-
-            # partial trace
-            @test bpcheck(aa -> einsum!(((1,2,2,3),), (aa,), (1,3), zeros(T,2,2)) |> abs ∘ sum, aa)
-
-            # diag
-            @test bpcheck(aa -> einsum!(((1,2,2,3),), (aa,), (1,2,3), zeros(T,2,4,2)) |> abs ∘ sum, aa)
-
-            # permutation
-            @test bpcheck(a -> einsum!(((1,2),), (a,), (2,1), zeros(T,2,2)) |> abs ∘ sum, a)
-            @test bpcheck(t -> einsum!(((1,2,3,4),), (t,),(2,3,1,4), zeros(T,2,2,2,2)) |> abs ∘ sum, t)
-
-            # tensor contraction
-            @test bpcheck((t,a) -> einsum!(((1,2,3,4), (2,3)), (t,a), (1,4), zeros(T,2,2)) |> abs ∘ sum, t,a)
-            @test bpcheck((t,a) -> einsum!(((4,3,2,1), (2,3)), (t,a), (1,4), zeros(T,2,2)) |> abs ∘ sum, t,a)
-
-            # star-contraction
-            @test bpcheck((a,b,c) -> einsum!(((1,2),(1,3),(1,4)), (a,b,c), (2,3,4), zeros(T,2,2,2)) |> abs ∘ sum, a,b,c)
-
-            # star and contract
-            @test bpcheck((a,b,c) -> einsum!(((1,2),(1,2),(1,3)), (a,b,c), (3,), zeros(T,2)) |> abs ∘ sum, a,b,c)
-
-            # index-sum
-            a3 = rand(T,2,2,2)
-            @test bpcheck(a -> einsum!(((1,2,3),),(a,),(1,2), zeros(T,2,2)) |> abs ∘ sum, a3)
-
-            # Hadamard product
-            @test bpcheck((a,b) -> einsum!(((1,2),(1,2)), (a,b), (1,2), zeros(T,2,2)) |> abs ∘ sum, a, b)
-
-            # Outer
-            @test bpcheck((a,b) -> einsum!(((1,2),(3,4)),(a,b),(1,2,3,4), zeros(T,2,2,2,2)) |> abs ∘ sum, a, b)
-        end
-    end
-end
 
 @testset "einsum bp" begin
     for T in (Float64, ComplexF64)

--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -187,4 +187,5 @@ end
     a = randn(3,3)
     b = randn(4,4)
     @test_throws DimensionMismatch einsum(((1,2), (2,3)), (a, b), (1,3))
+    @test_throws ArgumentError OMEinsum.combineops(OMEinsum.Diag(1), OMEinsum.Trace(2))
 end

--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -82,10 +82,10 @@ end
     b = rand(100,100)
     einsum(((1,2),(2,3)), (a,b),(1,3))
     allocs1 = @allocated einsum(((1,2),(2,3)), (a,b),(1,3))
-    @test allocs1 < 10^5
+    @test_broken allocs1 < 10^5
     einsum(((1,2),(2,3),(3,4)), (a,b,b),(1,4))
     allocs2 = @allocated einsum(((1,2),(2,3),(3,4)), (a,b,b),(1,4))
-    @test allocs2 < 1.1 * allocs1
+    @test_broken allocs2 < 1.1 * allocs1
 end
 
 @testset "error handling" begin

--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -180,7 +180,9 @@ end
     @test allocs1 < 10^5
     einsum(((1,2),(2,3),(3,4)), (a,b,b),(1,4))
     allocs2 = @allocated einsum(((1,2),(2,3),(3,4)), (a,b,b),(1,4))
-    @test_broken allocs2 < 2 * allocs1
+    # doing twice the work (two multiplications instead of one) shouldn't
+    # incure much more than twice the allocations.
+    @test allocs2 < 2.1 * allocs1
 end
 
 @testset "error handling" begin

--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -75,6 +75,79 @@ using Zygote
 
 end
 
+@testset "einsumopt" begin
+    # matrix and vector multiplication
+    a,b,c = randn(2,2), rand(2,2), rand(2,2)
+    v = rand(2)
+    t = randn(2,2,2,2)
+    @test einsumopt(((1,2),(2,3),(3,4)), (a,b,c)) ≈ a * b * c
+    @test einsumopt(((1,20),(20,3),(3,4)), (a,b,c)) ≈ a * b * c
+    @test einsumopt(((1,2),(2,3),(3,4)), (a,b,c), (4,1)) ≈ permutedims(a*b*c, (2,1))
+    @test einsumopt(((1,2),(2,)), (a,v)) ≈ a * v
+
+    # contract to 0-dim array
+    @test einsumopt(((1,2),(1,2)), (a,a), ())[] ≈ sum(a .* a)
+
+    # trace
+    @test einsumopt(((1,1),), (a,))[] ≈ sum(a[i,i] for i in 1:2)
+    aa = rand(2,4,4,2)
+    @test einsumopt(((1,2,2,1),), (aa,))[] ≈ sum(aa[i,j,j,i] for i in 1:2, j in 1:4)
+
+
+    # partial trace
+    @test einsumopt(((1,2,2,3),), (aa,)) ≈ sum(aa[:,i,i,:] for i in 1:4)
+
+    # diag
+    @test einsumopt(((1,2,2,3),), (aa,), (1,2,3)) ≈ aa[:,[CartesianIndex(i,i) for i in 1:4],:]
+
+
+    # permutation
+    @test einsumopt(((1,2),), (a,), (2,1)) ≈ permutedims(a,(2,1))
+    @test einsumopt(((1,2,3,4),), (t,),(2,3,1,4)) ≈ permutedims(t,(2,3,1,4))
+
+    # tensor contraction
+    ta = zeros(size(t)[[1,2]]...)
+    for (i,j,k,l) in Iterators.product(1:2,1:2,1:2,1:2)
+        ta[i,l] += t[i,j,k,l] * a[j,k]
+    end
+    @test einsumopt(((1,2,3,4), (2,3)), (t,a)) ≈  ta
+
+    ta = zeros(size(t)[[1,2]]...)
+    for (i,j,k,l) in Iterators.product(1:2,1:2,1:2,1:2)
+        ta[i,l] += t[l,k,j,i] * a[j,k]
+    end
+    @test einsumopt(((4,3,2,1), (2,3)), (t,a),(1,4)) ≈  ta
+
+    # star-contraction
+    aaa = zeros(2,2,2);
+    for (i,j,k,l) in Iterators.product(1:2,1:2,1:2,1:2)
+        aaa[j,k,l] += a[i,j] * a[i,k] * a[i,l]
+    end
+    @test aaa ≈ einsumopt(((1,2),(1,3),(1,4)), (a,a,a))
+
+    # star and contract
+    aaa = zeros(2);
+    for (i,j,l) in Iterators.product(1:2,1:2,1:2)
+        aaa[l] += a[i,j] * a[i,j] * a[i,l]
+    end
+    @test einsumopt(((1,2),(1,2),(1,3)), (a,a,a), (3,)) ≈ aaa
+
+    # index-sum
+    a = rand(2,2,5)
+    @test einsumopt(((1,2,3),),(a,),(1,2)) ≈ sum(a, dims=3)
+
+    # Hadamard product
+    a = rand(2,3)
+    b = rand(2,3)
+    @test einsumopt(((1,2),(1,2)), (a,b), (1,2)) ≈ a .* b
+
+    # Outer
+    a = rand(2,3)
+    b = rand(2,3)
+    @test einsumopt(((1,2),(3,4)),(a,b),(1,2,3,4)) ≈ reshape(a,2,3,1,1) .* reshape(b,1,1,2,3)
+
+end
+
 @testset "fallback" begin
     # while we expect some scaling in the allocations for multiple inputs, it
     # shouldn't increase too much

--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -73,6 +73,11 @@ using Zygote
     b = rand(2,3)
     @test einsum(((1,2),(3,4)),(a,b),(1,2,3,4)) ≈ reshape(a,2,3,1,1) .* reshape(b,1,1,2,3)
 
+    # Projecting to diag
+    a = rand(2,2)
+    a2 = [a[1] 0; 0 a[4]]
+    @test einsum(((1,1),), (a,), (1,1)) ≈ a2
+
 end
 
 @testset "einsumopt" begin
@@ -145,6 +150,11 @@ end
     a = rand(2,3)
     b = rand(2,3)
     @test einsumopt(((1,2),(3,4)),(a,b),(1,2,3,4)) ≈ reshape(a,2,3,1,1) .* reshape(b,1,1,2,3)
+
+    # Projecting to diag
+    a = rand(2,2)
+    a2 = [a[1] 0; 0 a[4]]
+    @test einsumopt(((1,1),), (a,), (1,1)) ≈ a2
 
 end
 

--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -78,6 +78,12 @@ using Zygote
     a2 = [a[1] 0; 0 a[4]]
     @test einsum(((1,1),), (a,), (1,1)) ≈ a2
 
+    ## operations that can be combined
+    a = rand(2,2,2,2)
+    @test einsum(((1,1,2,2),), (a,), ())[] ≈ sum(a[[CartesianIndex(i,i) for i in 1:2], [CartesianIndex(i,i) for i in 1:2]])
+
+    @test einsum(((1,2,3,4), (3,4,5,6)), (a,a), (1,2,5,6)) ≈ reshape(reshape(a,4,4) * reshape(a,4,4),2,2,2,2)
+
 end
 
 @testset "einsumopt" begin
@@ -155,6 +161,12 @@ end
     a = rand(2,2)
     a2 = [a[1] 0; 0 a[4]]
     @test einsumopt(((1,1),), (a,), (1,1)) ≈ a2
+
+    ## operations that can be combined
+    a = rand(2,2,2,2)
+    @test einsumopt(((1,1,2,2),), (a,), ())[] ≈ sum(a[[CartesianIndex(i,i) for i in 1:2], [CartesianIndex(i,i) for i in 1:2]])
+
+    @test einsumopt(((1,2,3,4), (3,4,5,6)), (a,a), (1,2,5,6)) ≈ reshape(reshape(a,4,4) * reshape(a,4,4),2,2,2,2)
 
 end
 

--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -155,10 +155,10 @@ end
     b = rand(100,100)
     einsum(((1,2),(2,3)), (a,b),(1,3))
     allocs1 = @allocated einsum(((1,2),(2,3)), (a,b),(1,3))
-    @test_broken allocs1 < 10^5
+    @test allocs1 < 10^5
     einsum(((1,2),(2,3),(3,4)), (a,b,b),(1,4))
     allocs2 = @allocated einsum(((1,2),(2,3),(3,4)), (a,b,b),(1,4))
-    @test_broken allocs2 < 1.1 * allocs1
+    @test_broken allocs2 < 2 * allocs1
 end
 
 @testset "error handling" begin


### PR DESCRIPTION
This is my proposal for how einsum could look like under the hood. The rough steps involved in an optimized einsum (at the moment `meinsumopt`) are:

1. from the indices in the input, set up a list of edges that need to be contracted, i.e. indices involved in contractions, traces, star-contractions, index reduction etc.
2. Translate these edges to _operations_, which are assigned types such as `Trace` or `StarContraction`.
3. check all possible permutations of those operations for their cost. Cost is naively calulated as the number of loop-iterations that a for-based einsum would have to evaluate evaluating operations one after another.
4. Take the cheapest evaluation order
5. For all operators in the cheapest order, check if they are actually what's evaluated. I.e. if a contraction (purely from the indices) changes to a trace (because the involved tensors are contracted before in the evaluation order), actually say it's a trace that has to be evaluated.
Now, given an optimal order and list of operations, evaluate the operations one by one by calling
`evaluate(operation, allindices, alltensors)`
operations are encoded by their type and thus `evaluate` can dispatch on the types of tensors *and* the types of operations. E.g. for TensorContractions it can call `TensorOperations`. Generic fallback is einsum.

After all operations are evaluated, the final result is permuted according to the required output `iy`.

Current implementation suffers from performance problems in the order optimisation, missing ability to combine operations (e.g. fusing indices shared between two tensors) and some hacks. But the framework should be ok I think. It would also be nice if the mapping from edges&indices to operations could be expandable - maybe with traits?

@GiggleLiu 