### PR TITLE
Fix AD for string-specification

### DIFF
--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -1,5 +1,7 @@
 using Zygote
 
+@Zygote.nograd parseeinsumsstring
+
 @doc raw"
     einsum_grad(ixs, xs, iy, y, i)
 return gradient w.r.t the `i`th tensor in `xs`

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -6,13 +6,18 @@ function outindsfrominput(ixs)
     return tuple(iy...)
 end
 
-function einsum(s::AbstractString, xs)
+function parseeinsumsstring(s::AbstractString)
     s = replace(s, " " => "")
     m = match(r"([a-z,]+)->([a-z]*)", s)
     m == nothing && throw(ArgumentError("invalid einsum specification $s"))
     sixs, siy = m.captures
     iy  = Tuple(siy)
     ixs = Tuple(Tuple(ix) for ix in split(sixs,','))
+    return (ixs, iy)
+end
+
+function einsum(s::AbstractString, xs)
+    ixs, iy = parseeinsumsstring(s)
     return einsum(ixs, xs, iy)
 end
 

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -68,3 +68,11 @@ end
     b = randn(3,3)
     @test array_match(gradient(a->einsum(((1,2), (2,3)), (a, b), ())[] |> abs, a)[1], a)
 end
+
+@testset "string-specification" begin
+    a,b,c = rand(2,2), rand(2,2), rand(2,2)
+    v = rand(2)
+    @test bpcheck((a,b,c) -> einsum("ij,jk,kl -> il", (a,b,c)) |> abs ∘ sum ,a,b,c)
+    @test bpcheck((a,b,c) -> einsum("ij,jk,kl -> li", (a,b,c)) |> abs ∘ sum ,a,b,c)
+    @test bpcheck((a,v) -> einsum("ij,j -> i", (a,v)) |> abs ∘ sum , a, v)
+end


### PR DESCRIPTION
Currently, AD fails if a string-specification is used. This PR solves that