### PR TITLE
Add specify order

### DIFF
--- a/src/OMEinsum.jl
+++ b/src/OMEinsum.jl
@@ -15,5 +15,6 @@ function __init__()
 end
 
 include("interfaces.jl")
+include("einsequence.jl")
 include("autodiff.jl")
 end # module

--- a/src/einsequence.jl
+++ b/src/einsequence.jl
@@ -1,23 +1,27 @@
-# macro eins_str(s::AbstractString)
-#     s = replace(s, " " => "")
-#     m = match(r"([\(\)a-z,]+)->([a-z]*)", s)
-#     m == nothing && throw(ArgumentError("invalid einsum specification $s"))
-#     sixs, siy = m.captures
-#     iy  = Tuple(siy)
-#     ixs = Tuple(Tuple(ix) for ix in split(sixs,','))
-#     return EinCode(ixs, iy)
-# end
-
+"""
+    parse_nested(s::AbstractString (, iy = []))
+return a contraction-tree consisting of `NestedEinsum`
+objects as nodes and `IndexGroup` as leaves.
+`s` should only contain the `ixs` part
+"""
 
 function parse_nested(s::AbstractString, iy = [])
+    count(==('('),s) == count(==(')'),s) || throw(
+        ArgumentError("Parentheses don't pair up in $s"))
     _, out = parse_level(s, firstindex(s), 1)
     out.iy = iy
     filliys!(out)
     return out
 end
 
+"""
+    parse_level(s::AbstractString, i, narg)
+parse one level of parantheses starting at index `i` where `narg` counts which tensor the
+current group of indices, e.g. "ijk", belongs to.
+Recursively calls itself for each new parantheses that's opened.
+"""
 function parse_level(s::AbstractString, i, narg)
-    out = Contraction([], 0, Set(), [])
+    out = NestedEinsum([], 0, Vector(), [])
     g = IndexGroup([],narg)
     while i <= lastindex(s)
         c = s[i]
@@ -25,13 +29,13 @@ function parse_level(s::AbstractString, i, narg)
         if c === '('
             j, out2, narg = parse_level(s, j, narg)
             out = push!(out, out2)
-            union!(out.indswithin, out2.indswithin)
+            union!(out.inds, out2.inds)
             out.nargs += out2.nargs
         elseif c === ')' || c === ','
             if !isempty(g)
                 push!(out, g)
                 out.nargs += 1
-                union!(out.indswithin, g.inds)
+                union!(out.inds, g.inds)
             end
             if  c === ','
                 narg += 1
@@ -42,38 +46,44 @@ function parse_level(s::AbstractString, i, narg)
         elseif isletter(c)
             g = push!(g,c)
         else
-            error()
+            throw(ArgumentError("parsing $s failed, $c is not a valid entry"))
         end
         i = j
     end
     if !isempty(g)
         out.nargs += 1
         push!(out, g)
-        union!(out.indswithin, g.inds)
+        union!(out.inds, g.inds)
     end
     return i, out
 end
 
-function filliys!(cont)
-    iy = cont.iy
-    args = cont.args
-    for i in 1:length(cont.args)
+"""
+    filliys!(neinsum::NestedEinsum)
+goes through all `NestedEinsum` objects in the tree and saves the correct `iy` in them.
+"""
+function filliys!(neinsum)
+    iy = neinsum.iy
+    args = neinsum.args
+    for i in 1:length(neinsum.args)
         arg = args[i]
         arg isa IndexGroup && continue
-        union!(arg.iy, intersect(arg.indswithin, iy))
-        for j in 1:length(cont.args)
+        union!(arg.iy, intersect(arg.inds, iy))
+        for j in 1:length(neinsum.args)
             i === j && continue
-            if args[j] isa IndexGroup
-                union!(arg.iy, intersect(arg.indswithin, args[j].inds))
-            else
-                union!(arg.iy, intersect(arg.indswithin, args[j].indswithin))
-            end
+            union!(arg.iy, intersect(arg.inds, args[j].inds))
         end
         filliys!(arg)
     end
-    return cont
+    return neinsum
 end
 
+"""
+    IndexGroup
+Leaf in a contractiontree, contains the indices and the number of the tensor it
+describes, e.g. in "ij,jk -> ik", indices "ik" belong to tensor `1`, so
+would be described by IndexGroup(['i','k'], 1).
+"""
 struct IndexGroup
     inds::Vector{Char}
     n::Int
@@ -82,49 +92,75 @@ end
 Base.push!(ig::IndexGroup, c::Char) = (push!(ig.inds,c); ig)
 Base.isempty(ig::IndexGroup) = isempty(ig.inds)
 
-mutable struct Contraction
-    args::Vector{Union{Contraction, IndexGroup}}
+"""
+    NestedEinsum
+describes a (potentially) nested einsum. Important fields:
+- `args`, vector of all inputs, either `IndexGroup` objects corresponding to tensors or `NestedEinsum`
+- `iy`, indices of output
+"""
+mutable struct NestedEinsum
+    args::Vector{Union{NestedEinsum, IndexGroup}}
     nargs::Int
-    indswithin::Set{Char}
+    inds::Vector{Char}
     iy::Vector{Char}
 end
 
-Base.push!(cont::Contraction, x) = (push!(cont.args,x); cont)
+Base.push!(neinsum::NestedEinsum, x) = (push!(neinsum.args,x); neinsum)
 
-@time parse_nested("((ij,iab),jcd),afce", collect("bdfe"))
-@time parse_nested("(ij,jk),kl", collect("im"))
-@time parse_nested("(ij,jk),(kl,lm)", collect("im"))
-
-using BenchmarkTools
-@btime parse_nested("((ij,iab),jcd),afce", collect("bdfe"))
-@btime parse_nested("(ij,jk),kl", collect("im"))
-@btime parse_nested("(ij,jk),(kl,lm)", collect("im"))
-
-
-using OMEinsum
-function foo(cont::Contraction)
-    ixs = Tuple(map(extractixs,cont.args))
-    iy = Tuple(cont.iy)
-    Expr(:call, :EinCode, ixs, iy)
+"""
+apply a NestedEinsum to arguments evaluates the nested einsum
+"""
+function (neinsum::NestedEinsum)(xs...; size_dict = nothing)
+    ixs = Tuple(map(extractixs, neinsum.args))
+    iy = Tuple(neinsum.iy)
+    EinCode(ixs,iy)(map(arg -> extractxs(xs, arg), neinsum.args)...)
 end
 
+"""
+extract the indices of the tensor that is associated with x (if x isa IndexGroup)
+or results from x (if x isa NestedEinsum)
+"""
 extractixs(x::IndexGroup) = Tuple(x.inds)
-extractixs(x::Contraction) = Tuple(x.iy)
+extractixs(x::NestedEinsum) = Tuple(x.iy)
 
-cont =  parse_nested("(ij,jk),(kl,lm)", collect("im"))
-foo(cont) |> eval
-eval(foo(cont))(rand(2,2),rand(2,2))
+"""
+extract the tensor associated with x (if x isa IndexGroup)
+or evaluate and return the tensor associated with x (if x isa NestedEinsum)
+"""
+extractxs(xs, x::NestedEinsum) = x(xs...)
+extractxs(xs, x::IndexGroup) = xs[x.n]
 
-function bar(x)
-    :(y -> y * $x)
-end
-
-function barbar(::Val{x}) where x
-    bar(x)
-end
-
-eval(bar(2))(2)
-barbar(Val(2))
-
-Foo(Foo(1,2),3)
-x -> foo(foo(x[1],x[2]), x[3])
+# @time parse_nested("((ij,iab),jcd),afce", collect("bdfe"))
+# @time parse_nested("(ij,jk),kl", collect("il"))
+# @time parse_nested("((ij,jk),kl)", collect("il"))
+# test =  parse_nested("(ij,jk),kl", collect("il"))
+# @time parse_nested("(ij,jk),(kl,lm)", collect("im"))
+#
+# using BenchmarkTools
+# @btime parse_nested("((ij,iab),jcd),afce", collect("bdfe"))
+# @btime parse_nested("(ij,jk),kl", collect("im"))
+# @btime parse_nested("(ij,jk),(kl,lm)", collect("im"))
+#
+# nein1 = parse_nested("(ij,jk),kl", collect("il"))
+# nein2 = parse_nested("((ij,jk),kl)", collect("il"))
+# a, b, c = rand(2,2), rand(2,2), rand(2,2)
+#
+# nein1(a,b,c) ≈ nein2(a,b,c)
+#
+#
+#
+#
+# parse_nested("(ij,jk),kl", collect("il"))(a,b,c) ≈ ein"ij,jk,kl -> il"(a,b,c)
+# χ = 100
+# a, b, c = [rand(χ,χ) for _ in 1:3]
+# parse_nested("(ij,jk),kl", collect("il"))(a,b,c) ≈ ein"ij,jk,kl -> il"(a,b,c)
+# @time parse_nested("(ij,jk),kl", collect("il"))(a,b,c)
+# @time ein"ij,jk,kl -> il"(a,b,c)
+#
+# using BenchmarkTools
+# χ = 20
+# a, b, c = [rand(χ,χ) for _ in 1:3]
+# @btime parse_nested("(ij,jk),kl", collect("il"))($a,$b,$c)
+# @btime ein"ij,jk,kl -> il"($a,$b,$c)
+# @btime ein"ij,jk -> ik"($a,$b)
+# @btime $a * $b * $c

--- a/src/einsequence.jl
+++ b/src/einsequence.jl
@@ -1,0 +1,130 @@
+# macro eins_str(s::AbstractString)
+#     s = replace(s, " " => "")
+#     m = match(r"([\(\)a-z,]+)->([a-z]*)", s)
+#     m == nothing && throw(ArgumentError("invalid einsum specification $s"))
+#     sixs, siy = m.captures
+#     iy  = Tuple(siy)
+#     ixs = Tuple(Tuple(ix) for ix in split(sixs,','))
+#     return EinCode(ixs, iy)
+# end
+
+
+function parse_nested(s::AbstractString, iy = [])
+    _, out = parse_level(s, firstindex(s), 1)
+    out.iy = iy
+    filliys!(out)
+    return out
+end
+
+function parse_level(s::AbstractString, i, narg)
+    out = Contraction([], 0, Set(), [])
+    g = IndexGroup([],narg)
+    while i <= lastindex(s)
+        c = s[i]
+        j = nextind(s,i)
+        if c === '('
+            j, out2, narg = parse_level(s, j, narg)
+            out = push!(out, out2)
+            union!(out.indswithin, out2.indswithin)
+            out.nargs += out2.nargs
+        elseif c === ')' || c === ','
+            if !isempty(g)
+                push!(out, g)
+                out.nargs += 1
+                union!(out.indswithin, g.inds)
+            end
+            if  c === ','
+                narg += 1
+                g = IndexGroup([], narg)
+            else
+                return j, out, narg
+            end
+        elseif isletter(c)
+            g = push!(g,c)
+        else
+            error()
+        end
+        i = j
+    end
+    if !isempty(g)
+        out.nargs += 1
+        push!(out, g)
+        union!(out.indswithin, g.inds)
+    end
+    return i, out
+end
+
+function filliys!(cont)
+    iy = cont.iy
+    args = cont.args
+    for i in 1:length(cont.args)
+        arg = args[i]
+        arg isa IndexGroup && continue
+        union!(arg.iy, intersect(arg.indswithin, iy))
+        for j in 1:length(cont.args)
+            i === j && continue
+            if args[j] isa IndexGroup
+                union!(arg.iy, intersect(arg.indswithin, args[j].inds))
+            else
+                union!(arg.iy, intersect(arg.indswithin, args[j].indswithin))
+            end
+        end
+        filliys!(arg)
+    end
+    return cont
+end
+
+struct IndexGroup
+    inds::Vector{Char}
+    n::Int
+end
+
+Base.push!(ig::IndexGroup, c::Char) = (push!(ig.inds,c); ig)
+Base.isempty(ig::IndexGroup) = isempty(ig.inds)
+
+mutable struct Contraction
+    args::Vector{Union{Contraction, IndexGroup}}
+    nargs::Int
+    indswithin::Set{Char}
+    iy::Vector{Char}
+end
+
+Base.push!(cont::Contraction, x) = (push!(cont.args,x); cont)
+
+@time parse_nested("((ij,iab),jcd),afce", collect("bdfe"))
+@time parse_nested("(ij,jk),kl", collect("im"))
+@time parse_nested("(ij,jk),(kl,lm)", collect("im"))
+
+using BenchmarkTools
+@btime parse_nested("((ij,iab),jcd),afce", collect("bdfe"))
+@btime parse_nested("(ij,jk),kl", collect("im"))
+@btime parse_nested("(ij,jk),(kl,lm)", collect("im"))
+
+
+using OMEinsum
+function foo(cont::Contraction)
+    ixs = Tuple(map(extractixs,cont.args))
+    iy = Tuple(cont.iy)
+    Expr(:call, :EinCode, ixs, iy)
+end
+
+extractixs(x::IndexGroup) = Tuple(x.inds)
+extractixs(x::Contraction) = Tuple(x.iy)
+
+cont =  parse_nested("(ij,jk),(kl,lm)", collect("im"))
+foo(cont) |> eval
+eval(foo(cont))(rand(2,2),rand(2,2))
+
+function bar(x)
+    :(y -> y * $x)
+end
+
+function barbar(::Val{x}) where x
+    bar(x)
+end
+
+eval(bar(2))(2)
+barbar(Val(2))
+
+Foo(Foo(1,2),3)
+x -> foo(foo(x[1],x[2]), x[3])

--- a/src/einsequence.jl
+++ b/src/einsequence.jl
@@ -10,7 +10,7 @@ function parse_nested(s::AbstractString, iy = [])
         ArgumentError("Parentheses don't pair up in $s"))
 
     _, out = parse_parens(s, firstindex(s), 1)
-    out.iy = iy
+    append!(out.iy, iy)
     filliys!(out)
     return stabilize(out)
 end
@@ -102,7 +102,7 @@ describes a (potentially) nested einsum. Important fields:
 - `args`, vector of all inputs, either `IndexGroup` objects corresponding to tensors or `NestedEinsum`
 - `iy`, indices of output
 """
-mutable struct NestedEinsum
+struct NestedEinsum
     args::Vector{Union{NestedEinsum, IndexGroup}}
     inds::Vector{Char}
     iy::Vector{Char}
@@ -133,7 +133,7 @@ or evaluate and return the tensor associated with x (if x isa NestedEinsum)
 extractxs(xs, x::NestedEinsum) = x(xs...)
 extractxs(xs, x::IndexGroup) = xs[x.n]
 
-mutable struct NestedEinsumStable{T,S,N}
+struct NestedEinsumStable{T,S,N}
     args::S
     eins::T
 end

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -18,12 +18,16 @@ end
 
 macro ein_str(s::AbstractString)
     s = replace(s, " " => "")
-    m = match(r"([a-z,]+)->([a-z]*)", s)
+    m = match(r"([\(\)a-z,]+)->([a-z]*)", s)
     m == nothing && throw(ArgumentError("invalid einsum specification $s"))
     sixs, siy = m.captures
-    iy  = Tuple(siy)
-    ixs = Tuple(Tuple(ix) for ix in split(sixs,','))
-    return EinCode(ixs, iy)
+    if '(' in sixs
+        return parse_nested(sixs, collect(siy))
+    else
+        iy  = Tuple(siy)
+        ixs = Tuple(Tuple(ix) for ix in split(sixs,','))
+        return EinCode(ixs, iy)
+    end
 end
 
 (code::EinCode)(xs...; size_dict=nothing) where {T, N} = einsum(code, xs, size_dict)

--- a/test/autodiff.jl
+++ b/test/autodiff.jl
@@ -75,3 +75,9 @@ end
     @test bpcheck((a,b,c) -> einsum(ein"ij,jk,kl -> li", (a,b,c)) |> abs ∘ sum ,a,b,c)
     @test bpcheck((a,v) -> einsum(ein"ij,j -> i", (a,v)) |> abs ∘ sum , a, v)
 end
+
+@testset "sequence specification" begin
+    a, b, c = rand(2,2), rand(2,2), rand(2,2)
+    @test all(gradient(sum ∘ ein"ij,jk,kl -> il", a, b, c) .≈
+          gradient(sum ∘ ein"(ij,(jk,kl)) -> il", a, b, c))
+end

--- a/test/einsequence.jl
+++ b/test/einsequence.jl
@@ -8,12 +8,10 @@ using OMEinsum: IndexGroup, NestedEinsum, parse_nested
     @test_throws ArgumentError parse_nested("((ij,jk),k1)")
 
     neinsum = parse_nested("(ij,jk),km", collect("im"))
-    @test neinsum.nargs == 3
     @test neinsum.iy == ['i','m']
 
     neinsum2 = neinsum.args[1]
     @test neinsum2.iy == ['i','k']
-    @test neinsum2.nargs == 2
 
     a, b, c = rand(2,2), rand(2,2), rand(2,2)
     abc1 = ein"(ij,jk),km -> im"(a,b,c)

--- a/test/einsequence.jl
+++ b/test/einsequence.jl
@@ -7,12 +7,6 @@ using OMEinsum: IndexGroup, NestedEinsum, parse_nested
     @test_throws ArgumentError parse_nested("((ij,jk),km")
     @test_throws ArgumentError parse_nested("((ij,jk),k1)")
 
-    neinsum = parse_nested("(ij,jk),km", collect("im"))
-    @test neinsum.iy == ['i','m']
-
-    neinsum2 = neinsum.args[1]
-    @test neinsum2.iy == ['i','k']
-
     a, b, c = rand(2,2), rand(2,2), rand(2,2)
     abc1 = ein"(ij,jk),km -> im"(a,b,c)
     abc2 = ein"((ij,jk),km) -> im"(a,b,c)

--- a/test/einsequence.jl
+++ b/test/einsequence.jl
@@ -1,0 +1,24 @@
+using Test, OMEinsum
+using OMEinsum: IndexGroup, NestedEinsum, parse_nested
+@testset "einsequence" begin
+    @test push!(IndexGroup([],1), 'c').inds == IndexGroup(['c'], 1).inds
+    @test isempty(IndexGroup([],1))
+
+    @test_throws ArgumentError parse_nested("((ij,jk),km")
+    @test_throws ArgumentError parse_nested("((ij,jk),k1)")
+
+    neinsum = parse_nested("(ij,jk),km", collect("im"))
+    @test neinsum.nargs == 3
+    @test neinsum.iy == ['i','m']
+
+    neinsum2 = neinsum.args[1]
+    @test neinsum2.iy == ['i','k']
+    @test neinsum2.nargs == 2
+
+    a, b, c = rand(2,2), rand(2,2), rand(2,2)
+    abc1 = ein"(ij,jk),km -> im"(a,b,c)
+    abc2 = ein"((ij,jk),km) -> im"(a,b,c)
+    abc3 = ein"ij,jk,km -> im"(a,b,c)
+
+    @test abc1 ≈ abc2 ≈ abc3
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,5 +19,7 @@ p = ProgressUnknown("Testset-running:")
     include("einorder.jl")
     next!(p)
     include("einsumopt.jl")
+    next!(p)
+    include("einsequence.jl")
     finish!(p)
 end


### PR DESCRIPTION
This is a work in progress to add order-specification by placing brackets.
While not much time has been invested in making it go fast, it already offers major advantages over a naive `EinCode`, compare e.g.
```julia
julia> a = rand(20,20);

julia> ein"ij,jk,kl -> il"(a,a,a) ≈ ein"(ij,jk),kl -> il"(a,a,a)
true

julia> @btime ein"ij,jk,kl -> il"($a,$a,$a);
  780.942 μs (12 allocations: 3.69 KiB)

julia> @btime ein"(ij,jk),kl -> il"($a,$a,$a);
  64.714 μs (66 allocations: 9.11 KiB)
```
For smaller arrays this advantage is smaller, see e.g.
```julia
julia> a = rand(10,10);
julia> @btime ein"ij,jk,kl -> il"($a,$a,$a);
  50.445 μs (12 allocations: 1.31 KiB)

julia> @btime ein"(ij,jk),kl -> il"($a,$a,$a);
  29.406 μs (66 allocations: 4.36 KiB)
```

Things worth pondering: 
- Does it make sense to have multiple structs or should `NestedEinsum` and `EinCode` be combined?
- Is there a good _intermediate representation_ that we could:
    - efficiently extract from strings
    - efficiently extract from macros
    - efficiently turn into either `EinCode` or `NestedEinsum`

@GiggleLiu , what do you think?