### PR TITLE
Implement julian macro with sequence specification

### DIFF
--- a/src/einsequence.jl
+++ b/src/einsequence.jl
@@ -89,11 +89,11 @@ describes, e.g. in "ij,jk -> ik", indices "ik" belong to tensor `1`, so
 would be described by IndexGroup(['i','k'], 1).
 """
 struct IndexGroup
-    inds::Vector{Char}
+    inds::Vector
     n::Int
 end
 
-Base.push!(ig::IndexGroup, c::Char) = (push!(ig.inds,c); ig)
+Base.push!(ig::IndexGroup, c) = (push!(ig.inds,c); ig)
 Base.isempty(ig::IndexGroup) = isempty(ig.inds)
 
 """
@@ -104,11 +104,49 @@ describes a (potentially) nested einsum. Important fields:
 """
 struct NestedEinsum
     args::Vector{Union{NestedEinsum, IndexGroup}}
-    inds::Vector{Char}
-    iy::Vector{Char}
+    inds::Vector
+    iy::Vector
 end
 
 Base.push!(neinsum::NestedEinsum, x) = (push!(neinsum.args,x); neinsum)
+
+using MacroTools
+
+function _nested_ein_macro(ex; einsum=:einsum)
+    @capture(ex, (left_ := right_)) || throw(ArgumentError("expected A[] := B[]... "))
+    @capture(left, Z_[leftind__] | [leftind__] ) || throw(
+        ArgumentError("can't understand LHS, expected A[i,j] etc."))
+    Z === nothing && @gensym Z
+    primefix!(leftind)
+    allinds = unique(leftind)
+
+    MacroTools.postwalk(right) do x
+        @capture(x, A_[inds__]) && union!(allinds, inds)
+        x
+    end
+    primefix!(allinds)
+
+    tensors = Symbol[]
+    nein = parse_nested_expr(right, tensors, allinds)
+    append!(nein.iy, indexin(leftind,allinds))
+    filliys!(nein)
+    snein = stabilize(nein)
+
+    tensornames = map(esc, tensors)
+    :($(esc(Z)) = $snein(($(tensornames...),)...))
+end
+
+function parse_nested_expr(expr, tensors, allinds)
+    if @capture(expr, *(args__))
+        einargs = map(x -> parse_nested_expr(x,tensors, allinds), args)
+        intinds = union(mapreduce(x -> x.inds, vcat, einargs))
+        return NestedEinsum(einargs, intinds, Int[])
+    elseif @capture(expr, A_[inds__])
+        push!(tensors,A)
+        return IndexGroup(indexin(primefix!(inds), allinds), length(tensors))
+    end
+end
+
 
 """
 apply a NestedEinsum to arguments evaluates the nested einsum

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -81,6 +81,7 @@ function check_dimensions(inds::IndexSize)
     return true
 end
 
+using MacroTools
 """
     @ein A[i,k] := B[i,j] * C[j,k]     # A = B * C
 
@@ -95,7 +96,6 @@ macro ein(exs...)
     _ein_macro(exs...)
 end
 
-using MacroTools
 
 primefix!(ind) = map!(i -> @capture(i, (j_)') ? Symbol(j, '′') : i, ind, ind)
 
@@ -111,8 +111,7 @@ function _ein_macro(ex; einsum=:einsum)
     rightind, rightpairs = [], []
     @capture(right, *(factors__)) || (factors = Any[right])
     for fact in factors
-        @capture(fact, A_[Aind__]) || throw(
-            ArgumentError("can't understand RHS, expected A[i,j] * B[k,l] etc."))
+        @capture(fact, A_[Aind__]) || return _nested_ein_macro(ex)
         primefix!(Aind)
         append!(rightind, Aind)
         push!(rightpairs, (A, Aind) )

--- a/test/einsequence.jl
+++ b/test/einsequence.jl
@@ -14,3 +14,10 @@ using OMEinsum: IndexGroup, NestedEinsum, parse_nested
 
     @test abc1 ≈ abc2 ≈ abc3
 end
+
+@testset "macro" begin
+    b, c, d = rand(2,2), rand(2,2,2), rand(2,2,2,2)
+    @ein a[i,j] := b[i,k] * c[k,k,l] * d[l,m,m,j]
+    @ein a2[i,j] := b[i,k] * (c[k,k,l] * d[l,m,m,j])
+    @test a ≈ a2
+end


### PR DESCRIPTION
First iteration simply translates to the intermediate structure that the 
string macro uses, although it could avoid the NestedEinsum Overhead. 
This is something we can change later though.