### PR TITLE
use CuArrays, CUDAnative, and CUDAdrv through .CuArrays

### DIFF
--- a/src/cudapatch.jl
+++ b/src/cudapatch.jl
@@ -1,10 +1,10 @@
-using CuArrays
-using CUDAdrv
+using .CuArrays
+using .CuArrays.CUDAnative
+using .CuArrays.CUDAdrv
 
-using CUDAnative, TupleTools
+using TupleTools
 using Base.Cartesian
-using GPUArrays
-import CuArrays: @cuindex
+import .CuArrays: @cuindex
 
 # patch file for CUDAnative and CuArrays.
 function CuArrays.mapreducedim_kernel_parallel(f, op, R::CuDeviceArray{T}, A,

--- a/src/cueinsum.jl
+++ b/src/cueinsum.jl
@@ -1,4 +1,5 @@
-using CuArrays, CUDAnative, GPUArrays
+using .CuArrays
+using .CuArrays.CUDAnative
 
 println("CUDA: YOU FIND ME!")
 


### PR DESCRIPTION
Since `CuArrays` is loaded through `@require`, it should be accessed as `using .CuArrays`. Furthermore, `CUDAnative` and `CUDAdrv` cannot be accessed directly at all (they are not `@require`d), but are both available by going through `CuArrays` (e.g., `using .CuArrays.CUDAnative`).

For me, `using OMEinsum` together with `using CuArrays` gave warnings and/or errors before, and works without problems after these changes.