### PR TITLE
Add debug macro logging

### DIFF
--- a/docs/src/implementation.md
+++ b/docs/src/implementation.md
@@ -102,3 +102,11 @@ two piece: `einarr = ein"ij,ik,il -> ijkl"(a,b,c)` and `ein"ijkl -> jkl"(einarr)
 but treat the first operation as a lazy one - this way we can use `mapreduce(identity, +)`
 over the dimensions we want to remove which is implemented efficiently for both
 regular `Array`s and `CuArray`s.
+
+## Debugging
+
+Calling `allow_loops(false)` will cause an error to be pinted when if the 
+fallback `loop_einsum` is used. This is an `@error` which does not interrupt execution. 
+
+Alternatively, a log of all methods used can be saved using `@debug` logging macro. 
+This is switched off by default, but can be printed by setting `ENV["JULIA_DEBUG"] = "all"`.

--- a/src/batched_contract.jl
+++ b/src/batched_contract.jl
@@ -35,10 +35,10 @@ function batched_contract(iAs, A::AbstractArray, iBs, B::AbstractArray, iOuts::N
     pA, sAb, sAs, sAp, pB, sBs, sBb, sBp, sAB, pOut = analyse_batched(iAs, size(A), iBs, size(B), iOuts)
 
     A, B = align_eltypes(A, B)
-    Apr = reshape(conditioned_permutedims(A, pA), sAb, sAs, sAp)
-    Bpr = reshape(conditioned_permutedims(B, pB), sBs, sBb, sBp)
+    Apr = reshape(conditioned_permutedims(A, pA, iAs), sAb, sAs, sAp)
+    Bpr = reshape(conditioned_permutedims(B, pB, iBs), sBs, sBb, sBp)
     AB = _batched_gemm('N','N', Apr, Bpr)
-    AB = conditioned_permutedims(reshape(AB, sAB...), [pOut...])
+    AB = conditioned_permutedims(reshape(AB, sAB...), pOut, iOuts)
 end
 
 # reload this function for GPU support!

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -32,22 +32,26 @@ true
 end
 
 function einsum(::Tr, ::EinCode, xs, size_dict)
+    @debug "Tr" size.(xs)
     asarray(tr(xs[1]), xs[1])
 end
 
 using TensorOperations
 
 function einsum(::PTrace, ::EinCode{ixs,iy}, xs::NTuple{<:Any, AbstractArray{<:BlasFloat}}, size_dict) where {ixs, iy}
+    @debug "PTrace tensortrace" ixs => iy size.(xs)
     asarray(tensortrace(xs[1], ixs[1], iy), xs[1])
 end
 
 # note that dispatching to Hadamard if some `ixs` are permuted has inferior
 # performance compared to the fallback
 function einsum(::Hadamard, ::EinCode{ixs, iy}, xs, size_dict) where {ixs, iy}
+    @debug "Hadamard" ixs => iy size.(xs)
     asarray(broadcast(*, xs...), xs[1])
 end
 
 function einsum(::PairWise, ::EinCode{ixs, iy}, xs::NTuple{NT,AbstractArray}, size_dict) where {ixs, iy, NT}
+    @debug "PairWise optcontract" ixs => iy size.(xs)
     optcontract(ixs, xs, iy)
 end
 
@@ -57,7 +61,13 @@ function einsum(sm::Sum, code::EinCode{ixs, iy}, xs, size_dict) where {ixs, iy}
     ix1f = filter!(i -> i in iy, collect(ix1))
     perm = map(i -> findfirst(==(i), ix1f), iy)
     res = dropdims(sum(xs[1], dims=dims), dims=dims)
-    perm == iy ? res : permutedims(res, perm)
+    if perm == iy
+        @debug "Sum" ixs => iy size.(xs)
+        res
+    else
+        @debug "Sum permutedims" ixs => iy size.(xs) perm
+        permutedims(res, perm)
+    end
 end
 
 @generated function einsum(sm::MatMul, code::EinCode{ixs, iy}, xs, size_dict) where {ixs, iy}
@@ -65,35 +75,43 @@ end
     l = ifelse(ix1[1] in ix2, ix1[1], ix1[2])
     if ix1[2] == l && ix2[1] == l
         if iy == (ix1[1], ix2[2])
-            #"ij,jk -> ik"
-            return :(xs[1] * xs[2])
+            return :(@debug "MatMul1 (ij,jk -> ik)" ixs => iy size.(xs);
+                xs[1] * xs[2]
+            )
         else
-            #"ij,jk -> ki"
-            return :(permutedims(xs[1] * xs[2]))
+            return :(@debug "MatMul2 (ij,jk -> ki) permutedims(ik)" ixs => iy size.(xs);
+                permutedims(xs[1] * xs[2])
+            )
         end
     elseif ix1[1] == l && ix2[1] == l
         if iy == (ix1[2], ix2[2])
-            #"ji,jk -> ik"
-            return :(transpose(xs[1]) * xs[2])
+            return :(@debug "MatMul3 (ji,jk -> ik) transpose(ij)" ixs => iy size.(xs);
+                transpose(xs[1]) * xs[2]
+            )
         else
-            #"ji,jk -> ki"
-            return :(transpose(xs[2]) * xs[1])
+            return :(@debug "MatMul4 (ji,jk -> ki) transpose(jk)" ixs => iy size.(xs);
+                transpose(xs[2]) * xs[1]
+            )
         end
     elseif ix1[2] == l && ix2[2] == l
         if iy == (ix1[1], ix2[1])
-            #"ij,kj -> ik"
-            return :(xs[1] * transpose(xs[2]))
+            return :(@debug "MatMul5 (ij,kj -> ik) transpose(jk)" ixs => iy size.(xs);
+                xs[1] * transpose(xs[2])
+            )
         else
-            #"ij,kj -> ki"
-            return :(xs[2] * transpose(xs[1]))
+            return :(@debug "MatMul6 (ij,kj -> ki) transpose(ij)" ixs => iy size.(xs);
+                xs[2] * transpose(xs[1])
+            )
         end
     else #ix1[1] == l && ix2[2] == l
         if iy == (ix1[2], ix2[1])
-            #"ji,kj -> ik"
-            return :(permutedims(xs[2] * xs[1]))
+            return :(@debug "MatMul7 (ji,kj -> ik) permutedims(ki)" ixs => iy size.(xs);
+                permutedims(xs[2] * xs[1])
+            )
         else
-            #"ji,kj -> ki"
-            return :(xs[2] * xs[1])
+            return :(@debug "MatMul8 (ji,kj -> ki)" ixs => iy size.(xs);
+                xs[2] * xs[1]
+            )
         end
     end
 end
@@ -102,23 +120,28 @@ function einsum(::Permutedims, code::EinCode{ixs, iy}, xs, size_dict) where {ixs
     (ix,) = ixs
     (x,) = xs
     perm = map(i -> findfirst(==(i), ix), iy)
+    @debug "Permutedims" ix => iy size(xs[1]) perm
     return permutedims(x, perm)
 end
 
 function einsum(::Identity, ::EinCode{ixs, iy}, xs, size_dict) where {ixs, iy}
+    # @debug "Identity" ixs => iy size(xs[1])
     xs[1]
 end
 
 # the fallback
 function einsum(::DefaultRule, code::EinCode{ixs, iy}, xs, size_dict) where {ixs, iy}
+    @debug "DefaultRule loop_einsum" ixs => iy size.(xs)
     loop_einsum(code, xs, size_dict)
 end
 
 function einsum(::PTrace, code::EinCode{ixs, iy}, xs::NTuple{NT, Any}, size_dict) where {ixs, iy, NT}
+    @debug "PTrace loop_einsum" ixs => iy size.(xs)
     loop_einsum(code, xs, size_dict)
 end
 
 function einsum(::BatchedContract, code::EinCode{ixs, iy}, xs::NTuple{NT, Any}, size_dict) where {ixs, iy, NT}
+    @debug "BatchedContract loop_einsum" ixs => iy size.(xs)
     loop_einsum(code, xs, size_dict)
 end
 
@@ -134,5 +157,6 @@ end
 function einsum(::BatchedContract, ::EinCode{ixs,iy}, xs::NTuple{<:Any, AbstractArray{<:BlasFloat}}, size_dict) where {ixs, iy}
     ixs1, xs1 = _preprocess_dupindices(ixs[1], xs[1])
     ixs2, xs2 = _preprocess_dupindices(ixs[2], xs[2])
+    @debug "BatchedContract" ixs => iy Tuple(ixs1) Tuple(ixs2) size.((xs1, xs2))
     batched_contract(ixs1, xs1, ixs2, xs2, iy)
 end

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -85,7 +85,7 @@ end
         end
     elseif ix1[1] == l && ix2[1] == l
         if iy == (ix1[2], ix2[2])
-            return :(@debug "MatMul3 (ji,jk -> ik) transpose(ij)" ixs => iy size.(xs);
+            return :(@debug "MatMul3 (ji,jk -> ik) transpose(ji)" ixs => iy size.(xs);
                 transpose(xs[1]) * xs[2]
             )
         else
@@ -95,7 +95,7 @@ end
         end
     elseif ix1[2] == l && ix2[2] == l
         if iy == (ix1[1], ix2[1])
-            return :(@debug "MatMul5 (ij,kj -> ik) transpose(jk)" ixs => iy size.(xs);
+            return :(@debug "MatMul5 (ij,kj -> ik) transpose(kj)" ixs => iy size.(xs);
                 xs[1] * transpose(xs[2])
             )
         else
@@ -125,7 +125,6 @@ function einsum(::Permutedims, code::EinCode{ixs, iy}, xs, size_dict) where {ixs
 end
 
 function einsum(::Identity, ::EinCode{ixs, iy}, xs, size_dict) where {ixs, iy}
-    # @debug "Identity" ixs => iy size(xs[1])
     xs[1]
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -61,8 +61,13 @@ false
 """
 allunique(ix::NTuple) = all(i -> count(==(i), ix) == 1, ix)
 
-function conditioned_permutedims(A::AbstractArray{T,N}, pA) where {T,N}
-    any(i-> (@inbounds pA[i]!=i), 1:N) ? permutedims(A, pA) : A
+function conditioned_permutedims(A::AbstractArray{T,N}, perm) where {T,N}
+    if any(i-> (@inbounds perm[i]!=i), 1:N)
+        @debug "conditioned_permutedims" size(A) Tuple(perm)
+        return permutedims(A, perm)
+    else
+        return A
+    end
 end
 
 function align_eltypes(xs::AbstractArray...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -61,9 +61,9 @@ false
 """
 allunique(ix::NTuple) = all(i -> count(==(i), ix) == 1, ix)
 
-function conditioned_permutedims(A::AbstractArray{T,N}, perm) where {T,N}
+function conditioned_permutedims(A::AbstractArray{T,N}, perm, ind=()) where {T,N}
     if any(i-> (@inbounds perm[i]!=i), 1:N)
-        @debug "conditioned_permutedims" size(A) Tuple(perm)
+        @debug "conditioned_permutedims" size(A) Tuple(perm) Tuple(ind)
         return permutedims(A, perm)
     else
         return A

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -17,7 +17,8 @@ end
 
 @testset "conditioned_permutedims" begin
     a = randn(100, 100)
-    OMEinsum.conditioned_permutedims(a, [1,2])
+    @test OMEinsum.conditioned_permutedims(a, [1,2]) == a
+    @test OMEinsum.conditioned_permutedims(a, (2,1)) == transpose(a)
     @test (@allocated OMEinsum.conditioned_permutedims(a, (1,2))) < 100
 end
 


### PR DESCRIPTION
This gives an easy way of seeing exactly what operations this thing does. 

I believe this should have zero overhead, for example I checked this one (which is quite verbose if you turn it on):
```
xx = rand(5,5,5); yy = rand(5,5,5);
@btime ein"ijb,jbk->ibk"($xx, $yy);
```