### PR TITLE
Faster permutedims using TensorOperations

### DIFF
--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -66,7 +66,7 @@ function einsum(sm::Sum, code::EinCode{ixs, iy}, xs, size_dict) where {ixs, iy}
         res
     else
         @debug "Sum permutedims" ixs => iy size.(xs) perm
-        permutedims(res, perm)
+        tensorpermute(res, perm)
     end
 end
 
@@ -121,7 +121,7 @@ function einsum(::Permutedims, code::EinCode{ixs, iy}, xs, size_dict) where {ixs
     (x,) = xs
     perm = map(i -> findfirst(==(i), ix), iy)
     @debug "Permutedims" ix => iy size(xs[1]) perm
-    return permutedims(x, perm)
+    return tensorpermute(x, perm)
 end
 
 function einsum(::Identity, ::EinCode{ixs, iy}, xs, size_dict) where {ixs, iy}

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -64,7 +64,7 @@ allunique(ix::NTuple) = all(i -> count(==(i), ix) == 1, ix)
 function conditioned_permutedims(A::AbstractArray{T,N}, perm, ind=()) where {T,N}
     if any(i-> (@inbounds perm[i]!=i), 1:N)
         @debug "conditioned_permutedims" size(A) Tuple(perm) Tuple(ind)
-        return permutedims(A, perm)
+        return tensorpermute(A, perm)
     else
         return A
     end
@@ -78,3 +78,13 @@ end
 function align_eltypes(xs::AbstractArray{T}...) where T
     xs
 end
+
+"""
+    tensorpermute(A, perm)
+
+Like `permutedims(A, perm)`, but calls the faster `TensorOperations.tensorcopy` when possible.
+"""
+function tensorpermute(A::StridedArray{T,N}, perm) where {T,N}
+    TensorOperations.tensorcopy(A, ntuple(identity,N), perm)
+end
+tensorpermute(A::AbstractArray, perm) = permutedims(A, perm)


### PR DESCRIPTION
This replaces `permutedims(A, perm)` with `TensorOperations.tensoradd`, which is much faster. 

I've no idea if this will work at all on CuArrays, nor whether it is quicker there. 

Ref #94 