### PR TITLE
Fix a debug message

### DIFF
--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -158,7 +158,6 @@ end
         ixs1, xs1 = _preprocess_dupindices($(Val(ixs[1])), xs[1])
         ixs2, xs2 = _preprocess_dupindices($(Val(ixs[2])), xs[2])
         @debug "BatchedContract" ixs => iy ixs1 ixs2 size(xs1) size(xs2)
-# @show size(xs1)
         batched_contract(ixs1, xs1, ixs2, xs2, $(Val(iy)))
     end
 end

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -157,7 +157,8 @@ end
     quote
         ixs1, xs1 = _preprocess_dupindices($(Val(ixs[1])), xs[1])
         ixs2, xs2 = _preprocess_dupindices($(Val(ixs[2])), xs[2])
-        @debug "BatchedContract" ixs => iy Tuple(ixs1) Tuple(ixs2) size.((xs1, xs2))
+        @debug "BatchedContract" ixs => iy ixs1 ixs2 size(xs1) size(xs2)
+# @show size(xs1)
         batched_contract(ixs1, xs1, ixs2, xs2, $(Val(iy)))
     end
 end


### PR DESCRIPTION
This fixes a bug in #87, one of the debug messages gave an error:
```
julia> using OMEinsum

julia> ENV["JULIA_DEBUG"] = OMEinsum;

julia> A = rand(1:99.0,2,2,2); B = rand(1:99.0, 2,2,2);

julia> @ein C3[b,a,d] := A[a,b,c] * B[a,c,d]
┌ Error: Exception while generating log record in module OMEinsum at /Users/me/.julia/packages/OMEinsum/0rZnI/src/einsum.jl:160
│   exception =
│    MethodError: no method matching length(::Val{(1, 2, 3)})
```