### PR TITLE
greedy algorithm for optimizing einsum contraction order

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,12 +18,12 @@ TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 [compat]
 BatchedRoutines = "0.2"
 CUDA = "2, 3.1"
+ChainRulesCore = "0.9"
 Combinatorics = "1.0"
 MacroTools = "0.5"
 PkgBenchmark = "0.2"
 Requires = "0.5, 1"
 TupleTools = "1.2"
-ChainRulesCore = "0.9"
 julia = "1"
 
 [extras]
@@ -34,6 +34,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SymEngine = "123dc426-2d89-5057-bbad-38513e3affd8"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+TropicalNumbers = "b3a74e9c-7526-4576-a4eb-79c0d4c32334"
 
 [targets]
-test = ["Test", "LinearAlgebra", "ProgressMeter", "SymEngine", "Random", "Zygote", "DoubleFloats"]
+test = ["Test", "LinearAlgebra", "ProgressMeter", "SymEngine", "Random", "Zygote", "DoubleFloats", "TropicalNumbers"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Andreas Peter <andreas.peter.ch@gmail.com>"]
 version = "0.4.0"
 
 [deps]
+AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 BatchedRoutines = "a9ab73d0-e05c-5df1-8fde-d6a4645b8d8e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -33,8 +34,8 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SymEngine = "123dc426-2d89-5057-bbad-38513e3affd8"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 TropicalNumbers = "b3a74e9c-7526-4576-a4eb-79c0d4c32334"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [targets]
 test = ["Test", "LinearAlgebra", "ProgressMeter", "SymEngine", "Random", "Zygote", "DoubleFloats", "TropicalNumbers"]

--- a/src/OMEinsum.jl
+++ b/src/OMEinsum.jl
@@ -23,5 +23,7 @@ include("interfaces.jl")
 include("einsequence.jl")
 include("autodiff.jl")
 
+include("contractionorder/contractionorder.jl")
+
 include("deprecation.jl")
 end # module

--- a/src/binaryrules.jl
+++ b/src/binaryrules.jl
@@ -229,7 +229,7 @@ for (i1, X1) in enumerate([('i', 'j'), ('j', 'i')])
             X3B = (X3...,'l')
             C1 = i1==i3 ? 'N' : 'T'
             C2 = i2==i3 ? 'N' : 'T'
-            @eval function einsum(::SimpleBinaryRule{$X1B,$X2B,$X3B}, xs::NTuple{2, AbstractArray{<:BlasFloat}})
+            @eval function einsum(::SimpleBinaryRule{$X1B,$X2B,$X3B}, xs::NTuple{2, Any})
                 $(i3==1 ? :(_batched_gemm($C1, $C2, xs[1], xs[2])) : :(_batched_gemm($C2, $C1, xs[2], xs[1])))
             end
         end

--- a/src/contractionorder/contractionorder.jl
+++ b/src/contractionorder/contractionorder.jl
@@ -1,0 +1,117 @@
+module ContractionOrder
+
+export ContractionTree
+
+struct ContractionTree
+    left
+    right
+end
+
+function log2sumexp2(s)
+    ms = maximum(s)
+    return log2(sum(x->exp2(x - ms), s)) + ms
+end
+
+include("incidencelist.jl")
+include("greedy.jl")
+
+end
+
+using .ContractionOrder: IncidenceList, ContractionTree, contract_pair!, MinSpaceOut, tree_greedy, timespace_complexity
+export parse_eincode, ContractionOrder, optimize_greedy
+
+function parse_eincode!(incidence_list::IncidenceList, tree, vertices_order)
+    ti = findfirst(==(tree), vertices_order)
+    ti, ti
+end
+
+function parse_eincode!(incidence_list::IncidenceList, tree::ContractionTree, vertices_order)
+    ti, codei = parse_eincode!(incidence_list, tree.left, vertices_order)
+    tj, codej = parse_eincode!(incidence_list, tree.right, vertices_order)
+    dummy = Dict([e=>0 for e in keys(incidence_list.e2v)])
+    tc, sc, code = contract_pair!(incidence_list, vertices_order[ti], vertices_order[tj], dummy)
+    ti, NestedEinsum((codei, codej), EinCode(Tuple.(code.first), Tuple(code.second)))
+end
+
+function parse_eincode(incidence_list::IncidenceList{VT,ET}, tree::ContractionTree; vertices = collect(keys(incidence_list.v2e))) where {VT,ET}
+    parse_eincode!(copy(incidence_list), tree, vertices)[2]
+end
+
+function parse_tree(ein, vertices)
+    if ein isa NestedEinsum
+        if length(ein.args) != 2
+            error("This eincode is not a binary tree.")
+        end
+        left, right = parse_tree.(ein.args, Ref(vertices))
+        ContractionTree(left, right)
+    else
+        vertices[ein]
+    end
+end
+
+function optimize_greedy(code::EinCode{ixs, iy}, size_dict; method=MinSpaceOut()) where {ixs, iy}
+    if length(ixs) < 2
+        return code
+    end
+    T = promote_type(eltype.(ixs)...)
+    log2_edge_sizes = empty(size_dict)
+    for (k, v) in size_dict
+        log2_edge_sizes[k] = log2(v)
+    end
+    incidence_list = ContractionOrder.IncidenceList(Dict([i=>collect(T,ixs[i]) for i=1:length(ixs)]); openedges=collect(T,iy))
+    tree, tc, sc = tree_greedy(incidence_list, log2_edge_sizes; method=method)
+    parse_eincode!(incidence_list, tree, 1:length(ixs))[2]
+end
+
+optimize_greedy(code::Int, size_dict; method=MinSpaceOut()) = code
+
+function optimize_greedy(code::NestedEinsum, size_dict; method=MinSpaceOut())
+    args = optimize_greedy.(code.args, Ref(size_dict); method=method)
+    if length(code.args) > 2
+        # generate coarse grained hypergraph.
+        #hyper_incidence_list = code.eins  # TODO
+        #tree_greedy(hyper_incidence_list, log2_edge_sizes; method=method)
+        nested = optimize_greedy(code.eins, size_dict; method=method)
+        replace_args(nested, args)
+    else
+        NestedEinsum(args, code.eins)
+    end
+end
+
+function replace_args(nested::NestedEinsum, trueargs)
+    NestedEinsum(replace_args.(nested.args, Ref(trueargs)), nested.eins)
+end
+replace_args(nested::Int, trueargs) = trueargs[nested]
+
+ContractionOrder.timespace_complexity(ei::Int, log2_edge_sizes) = -Inf, -Inf
+function ContractionOrder.timespace_complexity(ei::NestedEinsum, log2_edge_sizes)
+    tcscs = timespace_complexity.(ei.args, Ref(log2_edge_sizes))
+    tc2, sc2 = timespace_complexity(ei.eins, log2_edge_sizes)
+    tc = ContractionOrder.log2sumexp2([getindex.(tcscs, 1)..., tc2])
+    sc = max(reduce(max, getindex.(tcscs, 2)), sc2)
+    return tc, sc
+end
+
+function ContractionOrder.timespace_complexity(ei::EinCode{ixs, iy}, log2_edge_sizes) where {ixs, iy}
+    # remove redundant legs
+    labels = vcat(collect.(ixs)..., collect(iy))
+    loop_inds = unique!(filter(l->count(==(l), labels)>=2, labels))
+
+    tc = isempty(loop_inds) ? -Inf : sum(l->log2_edge_sizes[l], loop_inds)
+    sc = isempty(iy) ? 0.0 : sum(l->log2_edge_sizes[l], iy)
+    return tc, sc
+end
+
+function _flatten(code::NestedEinsum, iy=nothing)
+    ixs = []
+    for i=1:length(code.args)
+        append!(ixs, _flatten(code.args[i], OMEinsum.getixs(code.eins)[i]))
+    end
+    return ixs
+end
+_flatten(i::Int, iy) = [i=>iy]
+
+function Base.Iterators.flatten(code::NestedEinsum)
+    ixd = Dict(_flatten(code))
+    EinCode(([ixd[i] for i=1:length(ixd)]...,), OMEinsum.getiy(code.eins))
+end

--- a/src/contractionorder/greedy.jl
+++ b/src/contractionorder/greedy.jl
@@ -1,0 +1,155 @@
+export tree_greedy, MinSpaceOut, MinSpaceDiff
+export timespace_complexity
+
+struct MinSpaceOut end
+struct MinSpaceDiff end
+
+struct LegInfo{ET}
+    l1::Vector{ET}
+    l2::Vector{ET}
+    l12::Vector{ET}
+    l01::Vector{ET}
+    l02::Vector{ET}
+    l012::Vector{ET}
+end
+
+"""
+    tree_greedy(incidence_list, log2_sizes)
+
+Compute greedy order, and the time and space complexities, the rows of the `incidence_list` are vertices and columns are edges.
+`log2_sizes` are defined on edges.
+"""
+function tree_greedy(incidence_list::IncidenceList{VT,ET}, log2_edge_sizes; method=MinSpaceOut()) where {VT,ET}
+    incidence_list = copy(incidence_list)
+    n = nv(incidence_list)
+    #tree_dict = collect(Any, 1:n)
+    log2_tcs = Float64[] # time complexity
+    log2_scs = Float64[]
+
+    tree = Dict{VT,Any}([v=>v for v in vertices(incidence_list)])
+    while true
+        cost_values = evaluate_costs(method, incidence_list, log2_edge_sizes)
+        local pair
+        vmin = Inf
+        for (k,v) in cost_values
+            if v < vmin
+                pair = k
+                vmin = v
+            end
+        end
+        log2_tc_step, sc, code = contract_pair!(incidence_list, pair..., log2_edge_sizes)
+        push!(log2_tcs, log2_tc_step)
+        push!(log2_scs, space_complexity(incidence_list, log2_edge_sizes))
+        if nv(incidence_list) > 1
+            tree[pair[1]] = ContractionTree(tree[pair[1]], tree[pair[2]])
+        else
+            return ContractionTree(tree[pair[1]], tree[pair[2]]), log2_tcs, log2_scs
+        end
+    end
+end
+
+function contract_pair!(incidence_list, vi, vj, log2_edge_sizes)
+    log2dim(legs) = sum(l->log2_edge_sizes[l], legs, init=0)
+    @assert vj > vi
+    # compute time complexity and output tensor
+    legsets = analyze_contraction(incidence_list, vi, vj)
+    D12,D01,D02,D012 = log2dim.(getfield.(Ref(legsets),3:6))
+    tc = D12+D01+D02+D012  # dangling legs D1 and D2 do not contribute
+
+    # einsum code
+    eout = legsets.l01 ∪ legsets.l02 ∪ legsets.l012
+    code = (edges(incidence_list, vi), edges(incidence_list, vj)) => eout
+    sc = log2dim(eout)
+
+    # change incidence_list
+    delete_vertex!(incidence_list, vj)
+    change_edges!(incidence_list, vi, eout)
+    for e in eout
+        replace_vertex!(incidence_list, e, vj=>vi)
+    end
+    remove_edges!(incidence_list, legsets.l1 ∪ legsets.l2 ∪ legsets.l12)
+    return tc, sc, code
+end
+
+function evaluate_costs(method, incidence_list::IncidenceList{VT,ET}, log2_edge_sizes) where {VT,ET}
+    # initialize cost values
+    cost_values = Dict{Tuple{VT,VT},Float64}()
+    for vi = vertices(incidence_list)
+        for vj in neighbors(incidence_list, vi)
+            if vj > vi
+                cost_values[(vi,vj)] = greedy_loss(method, incidence_list, log2_edge_sizes, vi, vj)
+            end
+        end
+    end
+    return cost_values
+end
+
+function analyze_contraction(incidence_list::IncidenceList{VT,ET}, vi::VT, vj::VT) where {VT,ET}
+    ei = edges(incidence_list, vi)
+    ej = edges(incidence_list, vj)
+    leg012,leg12,leg1,leg2,leg01,leg02 = ET[], ET[], ET[], ET[], ET[], ET[]
+    # external legs
+    for leg in ei ∪ ej
+        isext = leg ∈ incidence_list.openedges || !all(x->x==vi || x==vj, vertices(incidence_list, leg))
+        if isext
+            if leg ∈ ei
+                if leg ∈ ej
+                    push!(leg012, leg)
+                else
+                    push!(leg01, leg)
+                end
+            else
+                push!(leg02, leg)
+            end
+        else
+            if leg ∈ ei
+                if leg ∈ ej
+                    push!(leg12, leg)
+                else
+                    push!(leg1, leg)
+                end
+            else
+                push!(leg2, leg)
+            end
+        end
+    end
+    return LegInfo(leg1, leg2, leg12, leg01, leg02, leg012)
+end
+
+function greedy_loss(::MinSpaceOut, incidence_list, log2_edge_sizes, vi, vj)
+    log2dim(legs) = sum(l->log2_edge_sizes[l], legs, init=0)
+    legs = analyze_contraction(incidence_list, vi, vj)
+    log2dim(legs.l01)+log2dim(legs.l02)+log2dim(legs.l012) - 0.01*(log2dim(legs.l12)+log2dim(legs.l1)+log2dim(legs.l2))  # only counts external legs
+end
+
+function greedy_loss(::MinSpaceDiff, incidence_list, log2_edge_sizes, vi, vj)
+    log2dim(legs) = sum(l->log2_edge_sizes[l], legs, init=0)
+    legs = analyze_contraction(incidence_list, vi, vj)
+    D1,D2,D12,D01,D02,D012 = log2dim.(getfield.(Ref(legs), 1:6))
+    exp2(D01+D02+D012) - exp2(D1+D01+D12) - exp2(D2+D02+D12)  # out - in
+end
+
+function space_complexity(incidence_list, log2_sizes)
+    sc = 0.0
+    for v in vertices(incidence_list)
+        for e in edges(incidence_list, v)
+            sc += log2_sizes[e]
+        end
+    end
+    return sc
+end
+
+function contract_tree!(incidence_list::IncidenceList, tree::ContractionTree, log2_edge_sizes, tcs, scs)
+    vi = tree.left isa ContractionTree ? contract_tree!(incidence_list, tree.left, log2_edge_sizes, tcs, scs) : tree.left
+    vj = tree.right isa ContractionTree ? contract_tree!(incidence_list, tree.right, log2_edge_sizes, tcs, scs) : tree.right
+    tc, sc, code = contract_pair!(incidence_list, vi, vj, log2_edge_sizes)
+    push!(tcs, tc)
+    push!(scs, sc)
+    return vi
+end
+
+function timespace_complexity(incidence_list::IncidenceList, tree::ContractionTree, log2_edge_sizes)
+    tcs, scs = Float64[], Float64[]
+    contract_tree!(copy(incidence_list), tree, log2_edge_sizes, tcs, scs)
+    return log2sumexp2(tcs), maximum(scs)
+end

--- a/src/contractionorder/incidencelist.jl
+++ b/src/contractionorder/incidencelist.jl
@@ -1,0 +1,80 @@
+export IncidenceList
+
+struct IncidenceList{VT,ET}
+    v2e::Dict{VT,Vector{ET}}
+    e2v::Dict{ET,Vector{VT}}
+    openedges::Vector{ET}
+end
+
+function IncidenceList(v2e::Dict{VT,Vector{ET}}; openedges=ET[]) where {VT,ET}
+    e2v = Dict{ET,Vector{VT}}()
+    for (v, es) in v2e
+        for e in es
+            if haskey(e2v, e)
+                push!(e2v[e], v)
+            else
+                e2v[e] = [v]
+            end
+        end
+    end
+    IncidenceList(v2e, e2v, openedges)
+end
+
+Base.copy(il::IncidenceList) = IncidenceList(deepcopy(il.v2e), deepcopy(il.e2v), copy(il.openedges))
+
+function neighbors(il::IncidenceList{VT}, v) where VT
+    res = VT[]
+    for e in il.v2e[v]
+        for v in il.e2v[e]
+            push!(res, v)
+        end
+    end
+    return unique!(res)
+end
+vertices(il::IncidenceList) = keys(il.v2e)
+vertices(il::IncidenceList, e) = il.e2v[e]
+vertex_degree(il::IncidenceList, v) = length(il.v2e[v])
+edge_degree(il::IncidenceList, e) = length(il.e2v[v])
+edges(il::IncidenceList, v) = il.v2e[v]
+nv(il::IncidenceList) = length(il.v2e)
+ne(il::IncidenceList) = length(il.e2v)
+
+function delete_vertex!(incidence_list::IncidenceList{VT,ET}, vj::VT) where {VT,ET}
+    edges = pop!(incidence_list.v2e, vj)
+    for e in edges
+        vs = vertices(incidence_list, e)
+        res = findfirst(==(vj), vs)
+        if res !== nothing
+            deleteat!(vs, res)
+        end
+    end
+    return incidence_list
+end
+
+function change_edges!(incidence_list, vi, es)
+    incidence_list.v2e[vi] = es
+    return incidence_list
+end
+
+function remove_edges!(incidence_list, es)
+    for e in es
+        delete!(incidence_list.e2v, e)
+    end
+    return incidence_list
+end
+
+function replace_vertex!(incidence_list, e, pair)
+    el = incidence_list.e2v[e]
+    if pair.first ∈ el
+        if pair.second ∈ el
+            deleteat!(el, findfirst(==(pair.first), el))
+        else
+            replace!(el, pair)
+        end
+    else
+        if pair.second ∉ el
+            push!(el, pair.second)
+        end
+    end
+    return incidence_list
+end

--- a/src/einsequence.jl
+++ b/src/einsequence.jl
@@ -213,3 +213,4 @@ Base.show(io::IO, ::MIME"text/plain", e::EinCode) = show(io, e)
 _join(ix::NTuple{0}) = ""
 _join(ix::NTuple{N,Char}) where N = join(ix, "")
 _join(ix::NTuple{N,Int}) where N = join(ix, "∘")
+_join(ix::NTuple{N,Any}) where N = join(ix, "-")

--- a/src/einsequence.jl
+++ b/src/einsequence.jl
@@ -181,3 +181,35 @@ function match_rule(code::NestedEinsum)
 end
 
 match_rule(code::Int64) = code
+
+
+# Better printing
+using AbstractTrees
+
+function AbstractTrees.children(ne::NestedEinsum)
+    d = Dict()
+    for (k,item) in enumerate(ne.args)
+        d[k] = item isa Integer ? join(OMEinsum.getixs(ne.eins)[k]) : item
+    end
+    d
+end
+
+function AbstractTrees.printnode(io::IO, x::String)
+    print(io, x)
+end
+function AbstractTrees.printnode(io::IO, x::NestedEinsum)
+    print(io, x.eins)
+end
+
+function Base.show(io::IO, e::EinCode{ixs, iy}) where {ixs, iy}
+    s = join([_join(ix) for ix in ixs], ", ") * " -> " * _join(iy)
+    print(io, s)
+end
+function Base.show(io::IO, e::NestedEinsum)
+    print_tree(io, e)
+end
+Base.show(io::IO, ::MIME"text/plain", e::NestedEinsum) = show(io, e)
+Base.show(io::IO, ::MIME"text/plain", e::EinCode) = show(io, e)
+_join(ix::NTuple{0}) = ""
+_join(ix::NTuple{N,Char}) where N = join(ix, "")
+_join(ix::NTuple{N,Int}) where N = join(ix, "∘")

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -191,36 +191,3 @@ function einsum(::DefaultRule, ixs, iy, xs, size_dict)
     @debug "DefaultRule loop_einsum" ixs => iy size.(xs)
     loop_einsum(EinCode{ixs, iy}(), xs, size_dict)
 end
-
-
-# Better printing
-using AbstractTrees
-
-function AbstractTrees.children(ne::NestedEinsum)
-    d = Dict()
-    for (k,item) in enumerate(ne.args)
-        d[k] = item isa Integer ? join(OMEinsum.getixs(ne.eins)[k]) : item
-    end
-    d
-end
-
-function AbstractTrees.printnode(io::IO, x::String)
-    print(io, x)
-end
-function AbstractTrees.printnode(io::IO, x::NestedEinsum)
-    print(io, x.eins)
-end
-
-function Base.show(io::IO, e::EinCode{ixs, iy}) where {ixs, iy}
-    s = join([_join(ix) for ix in ixs], ", ") * " -> " * _join(iy)
-    print(io, s)
-end
-function Base.show(io::IO, e::NestedEinsum)
-    print_tree(io, e)
-end
-Base.show(io::IO, ::MIME"text/plain", e::NestedEinsum) = show(io, e)
-Base.show(io::IO, ::MIME"text/plain", e::EinCode) = show(io, e)
-_join(ix::NTuple{0}) = ""
-_join(ix::NTuple{N,Char}) where N = join(ix, "")
-_join(ix::NTuple{N,Int}) where N = join(ix, "∘")
-

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -1,4 +1,4 @@
-export @ein_str, @ein
+export @ein_str, @ein, ein
 """
     ein"ij,jk -> ik"(A,B)
 
@@ -20,6 +20,10 @@ true
 ```
 """
 macro ein_str(s::AbstractString)
+    ein(s)
+end
+
+function ein(s::AbstractString)
     s = replace(replace(s, "\n" => ""), " "=>"")
     m = match(r"([\(\)a-z,α-ω]*)->([a-zα-ω]*)", s)
     m === nothing && throw(ArgumentError("invalid einsum specification $s"))

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -191,3 +191,36 @@ function einsum(::DefaultRule, ixs, iy, xs, size_dict)
     @debug "DefaultRule loop_einsum" ixs => iy size.(xs)
     loop_einsum(EinCode{ixs, iy}(), xs, size_dict)
 end
+
+
+# Better printing
+using AbstractTrees
+
+function AbstractTrees.children(ne::NestedEinsum)
+    d = Dict()
+    for (k,item) in enumerate(ne.args)
+        d[k] = item isa Integer ? join(OMEinsum.getixs(ne.eins)[k]) : item
+    end
+    d
+end
+
+function AbstractTrees.printnode(io::IO, x::String)
+    print(io, x)
+end
+function AbstractTrees.printnode(io::IO, x::NestedEinsum)
+    print(io, x.eins)
+end
+
+function Base.show(io::IO, e::EinCode{ixs, iy}) where {ixs, iy}
+    s = join([_join(ix) for ix in ixs], ", ") * " -> " * _join(iy)
+    print(io, s)
+end
+function Base.show(io::IO, e::NestedEinsum)
+    print_tree(io, e)
+end
+Base.show(io::IO, ::MIME"text/plain", e::NestedEinsum) = show(io, e)
+Base.show(io::IO, ::MIME"text/plain", e::EinCode) = show(io, e)
+_join(ix::NTuple{0}) = ""
+_join(ix::NTuple{N,Char}) where N = join(ix, "")
+_join(ix::NTuple{N,Int}) where N = join(ix, "∘")
+

--- a/test/contractionorder.jl
+++ b/test/contractionorder.jl
@@ -1,0 +1,83 @@
+using OMEinsum
+using OMEinsum.ContractionOrder
+using OMEinsum.ContractionOrder: analyze_contraction, contract_pair!, evaluate_costs
+using TropicalNumbers
+
+using Test
+@testset "analyze contraction" begin
+    incidence_list = IncidenceList(Dict('A' => ['a', 'b', 'k', 'o', 'f'], 'B'=>['a', 'c', 'd', 'm', 'f'], 'C'=>['b', 'c', 'e', 'f'], 'D'=>['e'], 'E'=>['d', 'f']), openedges=['c', 'f', 'o'])
+    info = analyze_contraction(incidence_list, 'A', 'B')
+    @test Set(info.l1) == Set(['k'])
+    @test Set(info.l2) == Set(['m'])
+    @test Set(info.l12) == Set(['a'])
+    @test Set(info.l01) == Set(['b','o'])
+    @test Set(info.l02) == Set(['c', 'd'])
+    @test Set(info.l012) == Set(['f'])
+end
+
+@testset "tree greedy" begin
+    incidence_list = IncidenceList(Dict('A' => ['a', 'b'], 'B'=>['a', 'c', 'd'], 'C'=>['b', 'c', 'e', 'f'], 'D'=>['e'], 'E'=>['d', 'f']))
+    log2_edge_sizes = Dict([c=>i for (i,c) in enumerate(['a', 'b', 'c', 'd', 'e', 'f'])]...)
+    il = copy(incidence_list)
+    contract_pair!(il, 'A', 'B', log2_edge_sizes)
+    target = IncidenceList(Dict('A' => ['b', 'c', 'd'], 'C'=>['b', 'c', 'e', 'f'], 'D'=>['e'], 'E'=>['d', 'f']))
+    @test il.v2e == target.v2e
+    @test length(target.e2v) == length(il.e2v)
+    for (k,v) in il.e2v
+        @test sort(target.e2v[k]) == sort(v)
+    end
+    costs = evaluate_costs(MinSpaceOut(), incidence_list, log2_edge_sizes)
+    @test costs == Dict(('A', 'B')=>9-0.01, ('A', 'C')=>15-0.02, ('B','C')=>18-0.03, ('B','E')=>10-0.04, ('C','D')=>11-0.05, ('C', 'E')=>14-0.06)
+    tree, log2_tcs, log2_scs = tree_greedy(incidence_list, log2_edge_sizes)
+    @test log2_tcs == [10.0, 16, 15, 9]
+    @test tree == ContractionTree(ContractionTree('A', 'B'), ContractionTree(ContractionTree('C', 'D'), 'E'))
+    @test timespace_complexity(incidence_list, tree, log2_edge_sizes) == (log2(exp2(10)+exp2(16)+exp2(15)+exp2(9)), 11)
+    vertices = ['A', 'B', 'C', 'D', 'E']
+    optcode1 = parse_eincode(incidence_list, tree, vertices=vertices)
+    @test optcode1 isa OMEinsum.NestedEinsum
+    tree2 = OMEinsum.parse_tree(optcode1, vertices)
+    @test tree2 == tree
+
+    eincode = ein"ab,acd,bcef,e,df->"
+    size_dict = Dict([c=>(1<<i) for (i,c) in enumerate(['a', 'b', 'c', 'd', 'e', 'f'])]...)
+    optcode2 = optimize_greedy(eincode, size_dict) 
+    tc, sc = timespace_complexity(optcode2, log2_edge_sizes)
+    @test tc ≈ log2(exp2(10)+exp2(16)+exp2(15)+exp2(9))
+    @test sc == 11
+    @test optcode1 == optcode2
+    eincode3 = ein"(ab,acd),bcef,e,df->"
+    optcode3 = optimize_greedy(eincode3, size_dict) 
+    @test optcode1 == optcode3
+end
+
+@testset "fullerene" begin
+    function fullerene()
+        φ = (1+√5)/2
+        res = NTuple{3,Float64}[]
+        for (x, y, z) in ((0.0, 1.0, 3φ), (1.0, 2 + φ, 2φ), (φ, 2.0, 2φ + 1.0))
+            for (α, β, γ) in ((x,y,z), (y,z,x), (z,x,y))
+                for loc in ((α,β,γ), (α,β,-γ), (α,-β,γ), (α,-β,-γ), (-α,β,γ), (-α,β,-γ), (-α,-β,γ), (-α,-β,-γ))
+                    if loc ∉ res
+                        push!(res, loc)
+                    end
+                end
+            end
+        end
+        return res
+    end
+
+    c60_xy = fullerene()
+    c60_edges = [(i,j) for (i,(i2,j2,k2)) in enumerate(c60_xy), (j,(i1,j1,k1)) in enumerate(c60_xy) if i<j && (i2-i1)^2+(j2-j1)^2+(k2-k1)^2 < 5.0]
+    code = EinCode((c60_edges..., [(i,) for i=1:60]...), ())
+    size_dict = Dict([i=>2 for i in 1:60])
+    log2_edge_sizes = Dict([i=>1 for i in 1:60])
+    tc, sc = timespace_complexity(code, log2_edge_sizes)
+    @test tc == 60
+    @test sc == 0
+    optcode = optimize_greedy(code, size_dict)
+    tc2, sc2 = timespace_complexity(optcode, log2_edge_sizes)
+    @test sc2 == 10
+    xs = vcat([TropicalF64.([-1 1; 1 -1]) for i=1:90], [TropicalF64.([0, 0]) for i=1:60])
+    @test Base.Iterators.flatten(optcode) == code
+    @test optcode(xs...)[].n == 66
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,4 +16,6 @@ using CUDA
     include("autodiff.jl")
     include("einsequence.jl")
     include("interfaces.jl")
+
+    include("contractionorder.jl")
 end


### PR DESCRIPTION
The greedy algorithm for finding the optimal contraction order on a hyper-graph.

In the test, there is an example of finding the optimal contraction order on a C60 graph.

```julia
using OMEinsum

julia> code = ein"(abc,cde),(ce,sf,j),ak->ael"
aec, ec, ak -> ael
├─ ce, sf, j -> ec
│  ├─ sf
│  ├─ j
│  └─ ce
├─ ak
└─ abc, cde -> aec
   ├─ cde
   └─ abc


julia> optimize_greedy(code, Dict([c=>2 for c in "abcdefjkls"]))
ae, ak -> ea
├─ ak
└─ aec, ec -> ae
   ├─ ce,  -> ce
   │  ├─ sf, j -> 
   │  │  ├─ j
   │  │  └─ sf
   │  └─ ce
   └─ abc, cde -> aec
      ├─ cde
      └─ abc
```