### PR TITLE
manually construct contraction tree and flop counting

### DIFF
--- a/src/Core.jl
+++ b/src/Core.jl
@@ -1,4 +1,4 @@
-export EinCode, EinIndexer, EinArray
+export EinCode, EinIndexer, EinArray, DynamicEinCode, StaticEinCode
 export einarray, getiyv, getixsv
 
 """

--- a/src/Core.jl
+++ b/src/Core.jl
@@ -1,14 +1,26 @@
-export EinCode, EinIndexer, EinArray, DynamicEinCode, StaticEinCode
-export einarray, getiyv, getixsv
+export EinCode, EinIndexer, EinArray, DynamicEinCode, StaticEinCode, AbstractEinsum
+export einarray, getiyv, getixsv, uniquelabels, labeltype
+
+# include `EinCode`, `NestedEinsum` and `SlicedEinsum` (defined in OMEinsumContractionOrders).
+#
+# Required interfaces are:
+# * labeltype
+# * getixsv
+# * getiyv
+#
+# Optional interfaces are:
+# * uniquelabels
+abstract type AbstractEinsum end
+uniquelabels(code::AbstractEinsum) = unique!(vcat(getixsv(code)..., getiyv(code)))
 
 """
-    EinCode
+    EinCode <: AbstractEinsum
     EinCode(ixs, iy)
 
 Abstract type for sum-product contraction code.
 The constructor returns a `DynamicEinCode` instance.
 """
-abstract type EinCode end
+abstract type EinCode <: AbstractEinsum end
 
 """
     StaticEinCode{ixs, iy}

--- a/src/contractionorder/greedy.jl
+++ b/src/contractionorder/greedy.jl
@@ -93,7 +93,6 @@ end
 
 function contract_pair!(incidence_list, vi, vj, log2_edge_sizes)
     log2dim(legs) = isempty(legs) ? 0 : sum(l->log2_edge_sizes[l], legs)  # for 1.5, you need this patch because `init` kw is not allowed.
-    @assert vj > vi
     # compute time complexity and output tensor
     legsets = analyze_contraction(incidence_list, vi, vj)
     D12,D01,D02,D012 = log2dim.(getfield.(Ref(legsets),3:6))

--- a/src/einsequence.jl
+++ b/src/einsequence.jl
@@ -154,7 +154,7 @@ function parse_nested_expr(expr, tensors, allinds)
     end
 end
 
-struct NestedEinsum{ET}
+struct NestedEinsum{ET} <: AbstractEinsum
     args::Vector{NestedEinsum{ET}}
     tensorindex::Int  # -1 if not leaf
     eins::ET

--- a/test/contractionorder.jl
+++ b/test/contractionorder.jl
@@ -1,5 +1,6 @@
 using OMEinsum
 using OMEinsum.ContractionOrder
+using OMEinsum: StaticEinCode
 using OMEinsum.ContractionOrder: analyze_contraction, contract_pair!, evaluate_costs, contract_tree!, log2sumexp2
 using TropicalNumbers
 
@@ -45,6 +46,9 @@ end
     Random.seed!(2)
     optcode2 = optimize_greedy(eincode, size_dict) 
     tc, sc = timespace_complexity(optcode2, edge_sizes)
+    # test flop
+    @test tc ≈ log2(flops(optcode2, edge_sizes))
+    @test flops(ein"i->", Dict('i'=>4)) == 4
     @test 16 <= tc <= log2(exp2(10)+exp2(16)+exp2(15)+exp2(9))
     @test sc == 11
     @test optcode1 == optcode2
@@ -108,4 +112,18 @@ end
     @test optcode isa NestedEinsum
     a, b, c = [rand(3,3) for i=1:3]
     @test optcode(a, b, c) ≈ code(a, b, c)
+end
+
+@testset "contructing contraction tree manually" begin
+    code = ein"ij,jk,kl->ijl"
+    dcode = DynamicEinCode(ein"ij,jk,kl->ijl")
+    a, b, c = randn(2, 2), randn(2,2), randn(2,2)
+    ne1 = parse_nested(code, ContractionTree(ContractionTree(1, 2), 3))
+    ne2 = parse_nested(dcode, ContractionTree(ContractionTree(1, 2), 3))
+    ne3 = parse_nested(code, ContractionTree(ContractionTree(1, 3), 2))
+    @test typeof(ne1) == NestedEinsum{StaticEinCode}
+    @test typeof(ne2) == NestedEinsum{DynamicEinCode{Char}}
+    @test ne1(a,b,c) ≈ ein"(ij,jk),kl->ijl"(a,b,c)
+    @test ne2(a,b,c) ≈ ein"(ij,jk),kl->ijl"(a,b,c)
+    @test ne3(a,b,c) ≈ ein"(ij,jk),kl->ijl"(a,b,c)
 end

--- a/test/contractionorder.jl
+++ b/test/contractionorder.jl
@@ -1,6 +1,6 @@
 using OMEinsum
 using OMEinsum.ContractionOrder
-using OMEinsum: StaticEinCode
+using OMEinsum: parse_eincode
 using OMEinsum.ContractionOrder: analyze_contraction, contract_pair!, evaluate_costs, contract_tree!, log2sumexp2
 using TropicalNumbers
 
@@ -47,8 +47,8 @@ end
     optcode2 = optimize_greedy(eincode, size_dict) 
     tc, sc = timespace_complexity(optcode2, edge_sizes)
     # test flop
-    @test tc ≈ log2(flops(optcode2, edge_sizes))
-    @test flops(ein"i->", Dict('i'=>4)) == 4
+    @test tc ≈ log2(flop(optcode2, edge_sizes))
+    @test flop(ein"i->", Dict('i'=>4)) == 4
     @test 16 <= tc <= log2(exp2(10)+exp2(16)+exp2(15)+exp2(9))
     @test sc == 11
     @test optcode1 == optcode2
@@ -126,4 +126,10 @@ end
     @test ne1(a,b,c) ≈ ein"(ij,jk),kl->ijl"(a,b,c)
     @test ne2(a,b,c) ≈ ein"(ij,jk),kl->ijl"(a,b,c)
     @test ne3(a,b,c) ≈ ein"(ij,jk),kl->ijl"(a,b,c)
+    @test flop(code, Dict([l=>2 for l in uniquelabels(code)])) == 2^4
+    @test flop(ne1, Dict([l=>2 for l in uniquelabels(code)])) == 2^4 + 2^3
+    @test flop(ne2, Dict([l=>2 for l in uniquelabels(code)])) == 2^4 + 2^3
+
+    # label elimination order
+    @test label_elimination_order(ein"(ij,jk),kl->il") == ['j', 'k']
 end


### PR DESCRIPTION
```julia
julia> using SymEngine, OMEinsum

julia> code = ein"ij,jk,kl->ijl"
ij, jk, kl -> ijl

julia> nested = parse_nested(code, ContractionTree(ContractionTree(1, 2), 3))
ikj, kl -> ijl
├─ kl
└─ ij, jk -> ikj
   ├─ jk
   └─ ij

julia> flop(code, Dict([l=>Basic(:n) for l in uniquelabels(code)]))
n^4

julia> flop(nested, Dict([l=>Basic(:n) for l in uniquelabels(nested)]))
n^3 + n^4
```

Also, I added a utility to check the label elimination order (corresponds to vertex elimination order in graph theory):
```julia
julia> label_elimination_order(ein"(ij,jk),kl->il")
2-element Vector{Char}:
 'j': ASCII/Unicode U+006A (category Ll: Letter, lowercase)
 'k': ASCII/Unicode U+006B (category Ll: Letter, lowercase)
```

Added a new abstract type `AbstractEinsum` as a common parent of `NestedEinsum` and `EinCode`.