### PR TITLE
promote_type stack overflow fix

### DIFF
--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -96,7 +96,6 @@ function get_size_dict_unary!(ix, s, size_info::Dict{LT}) where LT
 end
 
 @inline function get_size_dict(ixs, xs, size_info=nothing)
-    # LT = promote_type(eltype.(ixs)...)
     LT = reduce(promote_type, eltype.(ixs))
     return get_size_dict!(ixs, xs, size_info===nothing ? Dict{LT,Int}() : size_info)
 end

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -96,7 +96,8 @@ function get_size_dict_unary!(ix, s, size_info::Dict{LT}) where LT
 end
 
 @inline function get_size_dict(ixs, xs, size_info=nothing)
-    LT = promote_type(eltype.(ixs)...)
+    # LT = promote_type(eltype.(ixs)...)
+    LT = reduce(promote_type, eltype.(ixs))
     return get_size_dict!(ixs, xs, size_info===nothing ? Dict{LT,Int}() : size_info)
 end
 

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -96,7 +96,7 @@ function get_size_dict_unary!(ix, s, size_info::Dict{LT}) where LT
 end
 
 @inline function get_size_dict(ixs, xs, size_info=nothing)
-    LT = reduce(promote_type, eltype.(ixs))
+    LT = foldl((a, b) -> promote_type(a, eltype(b)), ixs; init=Union{})
     return get_size_dict!(ixs, xs, size_info===nothing ? Dict{LT,Int}() : size_info)
 end
 


### PR DESCRIPTION
Fix for issue #160.
The fixed function is given by
```Julia
@inline function get_size_dict(ixs, xs, size_info=nothing)
    LT = reduce(promote_type, eltype.(ixs))
    return get_size_dict!(ixs, xs, size_info===nothing ? Dict{LT,Int}() : size_info)
end
```