### PR TITLE
Added inplace macro @ein!

### DIFF
--- a/src/OMEinsum.jl
+++ b/src/OMEinsum.jl
@@ -6,7 +6,7 @@ using OMEinsumContractionOrders
 using AbstractTrees
 import LinearAlgebra: BlasFloat
 
-export @ein_str, @ein, ein
+export @ein_str, @ein, @ein!, ein
 export einsum!, einsum, dynamic_einsum
 export EinCode, EinIndexer, EinArray, DynamicEinCode, StaticEinCode, AbstractEinsum, NestedEinsum, SlicedEinsum, DynamicNestedEinsum, StaticNestedEinsum
 export getiyv, getixsv, uniquelabels, labeltype

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -34,7 +34,7 @@ function einsum(code::AbstractEinsum, @nospecialize(xs::Tuple), size_dict::Dict 
 end
 
 # inplace einsum, EinCode as the input
-function einsum!(code::EinCode, @nospecialize(xs::Tuple), @nospecialize(y), sx, sy, size_dict::Dict)
+function einsum!(code::EinCode, @nospecialize(xs::Tuple), @nospecialize(y), sx, sy, size_dict::Dict = get_size_dict(getixs(code), xs))
     einsum!(getixs(code), getiy(code), xs, y, sx, sy, size_dict)
 end
 # inplace einsum, the fallback

--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -243,13 +243,25 @@ end
     #@test_throws ArgumentError einsum(ein"ij,123 -> k", (a,a))
 end
 
-@testset "macro input" begin
+@testset "non inplace macro input" begin
     a = randn(2,2)
     @test a * a ≈ @ein [i,k] := a[i,j] * a[j,k]
     @test sum(a[i,i] for i in 1:2) ≈ (@ein [] := a[i,i])[]
     @test [a[1,1] 0; 0 a[2,2]] ≈ @ein [i,i] := a[i,i]
     @test permutedims(a) ≈ @ein [α,a] := a[a,α]
     @test permutedims(a) ≈ @ein [α,1] := a[1,α]
+end
+
+@testset "inplace macro input" begin
+    a = randn(2,2)
+    b = randn(2,2)
+    c = randn(2,2)
+    t = randn(2,2)
+    cc = copy(c)
+    @ein! t[i,k] := a[i,j] * b[j,k]
+    @ein! c[i,k] += a[i,j] * b[j,k]
+    @test a * b ≈ t
+    @test cc + a * b ≈ c
 end
 
 @testset "argument checks" begin


### PR DESCRIPTION
Two new interfaces are added:
```julia
@ein! A[i, j] := B[i,k]...
@ein! A[i, j] += B[i,k]...
```
for inplace operations.
All test passed and some benchmarking are shown below:
```julia
julia> using OMEinsum

julia> a, b, c = rand(100, 100), rand(100, 100), zeros(100, 100);

julia> size_dict = Dict('i' => 100, 'j' => 100, 'k' => 100);

julia> using BenchmarkTools

julia> @benchmark @ein $c[i,j] := $a[i,k] * $b[k,j]
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  40.300 μs … 747.114 μs  ┊ GC (min … max): 0.00% … 88.91%
 Time  (median):     43.300 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   47.454 μs ±  28.280 μs  ┊ GC (mean ± σ):  1.63% ±  3.52%

   ▄▆██▇▆▅▅▄▃▂▁▁       ▁▂▂▂▂▂▂▂▂▁▁                             ▂
  ███████████████▇▆▆▅▇████████████▇▆▅▃▅▄▄▄▂▃▂▄▅▅▅▆▇▅▆▇▇▇▇▇▆▆▅▅ █
  40.3 μs       Histogram: log(frequency) by time      74.9 μs <

 Memory estimate: 81.64 KiB, allocs estimate: 60.

julia> @benchmark @ein! $c[i,j] := $a[i,k] * $b[k,j]
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  36.260 μs … 265.258 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     38.339 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   39.048 μs ±   8.942 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

           ▁▃▅▇▇█▆▆▄▂                                           
  ▁▁▁▁▂▃▃▆▇███████████▅▄▄▃▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▃
  36.3 μs         Histogram: frequency by time         44.8 μs <

 Memory estimate: 3.36 KiB, allocs estimate: 56.

julia> @benchmark @ein! $c[i,j] += $a[i,k] * $b[k,j]
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  35.020 μs … 265.588 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     37.090 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   37.918 μs ±  10.100 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

           ▂▅▅█▇▆▃                                              
  ▁▁▁▁▂▃▄▅▇███████▇▅▄▃▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  35 μs           Histogram: frequency by time         44.6 μs <

 Memory estimate: 3.36 KiB, allocs estimate: 56.

julia> @benchmark einsum!($(ein"ik, kj -> ij"), $(a, b), $c, true, false, $(size_dict))
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  33.280 μs … 335.577 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     35.670 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   36.678 μs ±   9.058 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

        ▃██▆▃                                                   
  ▁▁▁▂▄██████▇▅▃▂▂▃▃▃▃▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  33.3 μs         Histogram: frequency by time         49.1 μs <

 Memory estimate: 2.00 KiB, allocs estimate: 40.

julia> @benchmark einsum!($(ein"ik, kj -> ij"), $(a, b), $c, true, true, $(size_dict))
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  32.460 μs … 277.798 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     34.690 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   35.514 μs ±   9.793 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

            ▃▆▇█▇▃                                              
  ▁▁▁▁▁▁▂▃▅████████▆▄▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  32.5 μs         Histogram: frequency by time         42.4 μs <

 Memory estimate: 2.00 KiB, allocs estimate: 40.


```