### PR TITLE
fix trying to use AMDGPU in Base

### DIFF
--- a/ext/AMDGPUExt.jl
+++ b/ext/AMDGPUExt.jl
@@ -136,7 +136,3 @@ end
 @info("OMEinsum loaded the AMDGPU module successfully")
 
 end
-
-using AMDGPU
-
-AMDGPU.versioninfo()


### PR DESCRIPTION
Remove loading AMDGPU in AMDGPUext. This fixes the following:

```
julia> using AMDGPU, OMEinsum
Precompiling AMDGPUExt
        Info Given AMDGPUExt was explicitly requested, output will be shown live 
[ Info: OMEinsum loaded the AMDGPU module successfully
ERROR: LoadError: ArgumentError: Package Base does not have AMDGPU in its dependencies:
- You may have a partially installed environment. Try `Pkg.instantiate()`
  to ensure all packages in the environment are installed.
- Or, if you have Base checked out for development and have
  added AMDGPU as a dependency but haven't updated your primary
  environment's manifest file, try `Pkg.resolve()`.
- Otherwise you may need to report an issue with Base
Stacktrace:
...
```