### PR TITLE
Change default of `get_output_array` as `Array(undef, size...)`

### DIFF
--- a/ext/AMDGPUExt.jl
+++ b/ext/AMDGPUExt.jl
@@ -24,14 +24,14 @@ OMEinsum.safe_reshape(x::Transpose{T,<:ROCArray{T}} where {T}, sz) = reshape(ROC
 
 Base.Array(x::Base.ReshapedArray{T,0,<:ROCArray}) where {T} = Array(x.parent)
 
-function get_output_array(xs::NTuple{N,ROCArrayTypes{<:Any,M} where M}, size; fillzero=false) where {N}
+function get_output_array(xs::NTuple{N,ROCArrayTypes{<:Any,M} where M}, size, fillzero::Bool) where {N}
     if fillzero
         return AMDGPU.zeros(promote_type(map(eltype, xs)...), size...)
     else
         return ROCArray{promote_type(map(eltype, xs)...)}(undef, size...)
     end
 end
-function get_output_array(xs::NTuple{N,ROCArrayTypes{T,M} where M}, size; fillzero=false) where {T,N}
+function get_output_array(xs::NTuple{N,ROCArrayTypes{T,M} where M}, size, fillzero::Bool) where {T,N}
     if fillzero
         return AMDGPU.zeros(T, size...)
     else

--- a/ext/AMDGPUExt.jl
+++ b/ext/AMDGPUExt.jl
@@ -24,11 +24,19 @@ OMEinsum.safe_reshape(x::Transpose{T,<:ROCArray{T}} where {T}, sz) = reshape(ROC
 
 Base.Array(x::Base.ReshapedArray{T,0,<:ROCArray}) where {T} = Array(x.parent)
 
-function get_output_array(xs::NTuple{N,ROCArrayTypes{<:Any,M} where M}, size; fillzero=true) where {N}
-    AMDGPU.zeros(promote_type(map(eltype, xs)...), size...)
+function get_output_array(xs::NTuple{N,ROCArrayTypes{<:Any,M} where M}, size; fillzero=false) where {N}
+    if fillzero
+        return AMDGPU.zeros(promote_type(map(eltype, xs)...), size...)
+    else
+        return ROCArray{promote_type(map(eltype, xs)...)}(undef, size...)
+    end
 end
-function get_output_array(xs::NTuple{N,ROCArrayTypes{T,M} where M}, size; fillzero=true) where {T,N}
-    AMDGPU.zeros(T, size...)
+function get_output_array(xs::NTuple{N,ROCArrayTypes{T,M} where M}, size; fillzero=false) where {T,N}
+    if fillzero
+        return AMDGPU.zeros(T, size...)
+    else
+        return ROCArray{T}(undef, size...)
+    end
 end
 
 

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -24,14 +24,14 @@ OMEinsum.safe_reshape(x::Transpose{T, <:CuArray{T}} where T, sz) = reshape(CuArr
 
 Base.Array(x::Base.ReshapedArray{T,0,<:CuArray}) where T = Array(x.parent)
 
-function get_output_array(xs::NTuple{N, CUDAArrayTypes{<:Any,M} where M}, size; fillzero=false) where N
+function get_output_array(xs::NTuple{N, CUDAArrayTypes{<:Any,M} where M}, size, fillzero::Bool) where N
     if fillzero
         return CUDA.zeros(promote_type(map(eltype,xs)...), size...)
     else
         return CuArray{promote_type(map(eltype,xs)...)}(undef, size...)
     end
 end
-function get_output_array(xs::NTuple{N, CUDAArrayTypes{T,M} where M}, size; fillzero=false) where {T,N}
+function get_output_array(xs::NTuple{N, CUDAArrayTypes{T,M} where M}, size, fillzero::Bool) where {T,N}
     if fillzero
         return CUDA.zeros(T, size...)
     else

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -32,12 +32,11 @@ function get_output_array(xs::NTuple{N, CUDAArrayTypes{<:Any,M} where M}, size; 
     end
 end
 function get_output_array(xs::NTuple{N, CUDAArrayTypes{T,M} where M}, size; fillzero=false) where {T,N}
-    # if fillzero
-    #     return CUDA.zeros(T, size...)
-    # else
-    #     return CuArray{T}(undef, size...)
-    # end
-    return CuArray{T}(undef, size...)
+    if fillzero
+        return CUDA.zeros(T, size...)
+    else
+        return CuArray{T}(undef, size...)
+    end
 end
 
 CUDA.cudaconvert(A::EinArray{T}) where T = EinArray{T}(cudaconvert.(A.xs), A.x_indexers, A.y_indexer, A.size, A.ICIS, A.OCIS)

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -24,11 +24,19 @@ OMEinsum.safe_reshape(x::Transpose{T, <:CuArray{T}} where T, sz) = reshape(CuArr
 
 Base.Array(x::Base.ReshapedArray{T,0,<:CuArray}) where T = Array(x.parent)
 
-function get_output_array(xs::NTuple{N, CUDAArrayTypes{<:Any,M} where M}, size; fillzero=true) where N
-    CUDA.zeros(promote_type(map(eltype,xs)...), size...)
+function get_output_array(xs::NTuple{N, CUDAArrayTypes{<:Any,M} where M}, size; fillzero=false) where N
+    if fillzero
+        return CUDA.zeros(promote_type(map(eltype,xs)...), size...)
+    else
+        return CuArray{promote_type(map(eltype,xs)...)}(undef, size...)
+    end
 end
-function get_output_array(xs::NTuple{N, CUDAArrayTypes{T,M} where M}, size; fillzero=true) where {T,N}
-    CUDA.zeros(T, size...)
+function get_output_array(xs::NTuple{N, CUDAArrayTypes{T,M} where M}, size; fillzero=false) where {T,N}
+    if fillzero
+        return CUDA.zeros(T, size...)
+    else
+        return CuArray{T}(undef, size...)
+    end
 end
 
 CUDA.cudaconvert(A::EinArray{T}) where T = EinArray{T}(cudaconvert.(A.xs), A.x_indexers, A.y_indexer, A.size, A.ICIS, A.OCIS)

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -32,11 +32,12 @@ function get_output_array(xs::NTuple{N, CUDAArrayTypes{<:Any,M} where M}, size; 
     end
 end
 function get_output_array(xs::NTuple{N, CUDAArrayTypes{T,M} where M}, size; fillzero=false) where {T,N}
-    if fillzero
-        return CUDA.zeros(T, size...)
-    else
-        return CuArray{T}(undef, size...)
-    end
+    # if fillzero
+    #     return CUDA.zeros(T, size...)
+    # else
+    #     return CuArray{T}(undef, size...)
+    # end
+    return CuArray{T}(undef, size...)
 end
 
 CUDA.cudaconvert(A::EinArray{T}) where T = EinArray{T}(cudaconvert.(A.xs), A.x_indexers, A.y_indexer, A.size, A.ICIS, A.OCIS)

--- a/src/bp.jl
+++ b/src/bp.jl
@@ -137,7 +137,7 @@ end
 function init_gradient(code, xs)
     size_dict = get_size_dict!(getixsv(code), xs, Dict{labeltype(code), Int}())
     output_size = getindex.(Ref(size_dict), getiyv(code))
-    ȳ = get_output_array(xs, output_size)
+    ȳ = get_output_array(xs, output_size, false)
     return fill!(ȳ, one(eltype(ȳ)))
 end
 

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -22,7 +22,7 @@ true
 ```
 "
 function einsum(code::AbstractEinsum, @nospecialize(xs::Tuple), size_dict::Dict=get_size_dict!(getixs(code), xs, Dict{labeltype(code),Int}()))
-    y = get_output_array(xs, map(y -> size_dict[y], getiyv(code)); fillzero=true)
+    y = get_output_array(xs, map(y -> size_dict[y], getiyv(code)); fillzero=false)
     einsum!(code, xs, y, true, false, size_dict)
 end
 

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -22,7 +22,7 @@ true
 ```
 "
 function einsum(code::AbstractEinsum, @nospecialize(xs::Tuple), size_dict::Dict=get_size_dict!(getixs(code), xs, Dict{labeltype(code),Int}()))
-    y = get_output_array(xs, map(y -> size_dict[y], getiyv(code)); fillzero=false)
+    y = get_output_array(xs, map(y -> size_dict[y], getiyv(code)), false)
     einsum!(code, xs, y, true, false, size_dict)
 end
 

--- a/src/loop_einsum.jl
+++ b/src/loop_einsum.jl
@@ -45,14 +45,14 @@ function reduce_einarray!(A::EinArray{T}, y, sx) where T
 end
 
 # speed up the get output array for the case when the inputs have the same type.
-function get_output_array(xs::NTuple{N, AbstractArray{T,M} where M}, size; fillzero=true) where {T,N}
+function get_output_array(xs::NTuple{N, AbstractArray{T,M} where M}, size; fillzero=false) where {T,N}
     if fillzero
         zeros(T, size...)
     else
         Array{T}(undef, size...)
     end
 end
-function get_output_array(xs::NTuple{N, AbstractArray{<:Any,M} where M}, size; fillzero=true) where N
+function get_output_array(xs::NTuple{N, AbstractArray{<:Any,M} where M}, size; fillzero=false) where N
     if fillzero
         zeros(promote_type(map(eltype,xs)...), size...)
     else

--- a/src/loop_einsum.jl
+++ b/src/loop_einsum.jl
@@ -9,7 +9,7 @@ function loop_einsum(code::EinCode, xs::NTuple{N, AbstractArray{<:Any,M} where M
                 size_dict) where {N}
     iy = getiy(code)
     size = getindex.(Ref(size_dict), iy)
-    loop_einsum!(getixs(code), getiy(code), xs, get_output_array(xs, size; fillzero=false), true, false, size_dict)
+    loop_einsum!(getixs(code), getiy(code), xs, get_output_array(xs, size, false), true, false, size_dict)
 end
 
 """
@@ -45,14 +45,14 @@ function reduce_einarray!(A::EinArray{T}, y, sx) where T
 end
 
 # speed up the get output array for the case when the inputs have the same type.
-function get_output_array(xs::NTuple{N, AbstractArray{T,M} where M}, size; fillzero=false) where {T,N}
+function get_output_array(xs::NTuple{N, AbstractArray{T,M} where M}, size, fillzero::Bool) where {T,N}
     if fillzero
         zeros(T, size...)
     else
         Array{T}(undef, size...)
     end
 end
-function get_output_array(xs::NTuple{N, AbstractArray{<:Any,M} where M}, size; fillzero=false) where N
+function get_output_array(xs::NTuple{N, AbstractArray{<:Any,M} where M}, size, fillzero::Bool) where N
     if fillzero
         zeros(promote_type(map(eltype,xs)...), size...)
     else

--- a/src/slicing.jl
+++ b/src/slicing.jl
@@ -123,7 +123,7 @@ end
 function einsum(se::SlicedEinsum, @nospecialize(xs::NTuple{N,AbstractArray} where N), size_dict::Dict)
     length(se.slicing) == 0 && return einsum(se.eins, xs, size_dict)
     it = SliceIterator(se, size_dict)
-    res = get_output_array(xs, getindex.(Ref(size_dict), it.iyv))
+    res = get_output_array(xs, getindex.(Ref(size_dict), it.iyv), false)
     eins_sliced = drop_slicedim(se.eins, se.slicing)
     for slicemap in it  # `slicemap` is a Dict storing a mapping from sliced_labels to the current slice index
         # NOTE: @debug will break Zygote

--- a/test/binaryrules.jl
+++ b/test/binaryrules.jl
@@ -32,7 +32,7 @@ end
                     rule = match_rule(code)
                     if rule isa SimpleBinaryRule
                         nmatch += 1
-                        out = OMEinsum.get_output_array((a, b), [size_dict[l] for l in getiyv(code)]; fillzero=false)
+                        out = OMEinsum.get_output_array((a, b), [size_dict[l] for l in getiyv(code)], false)
                         @test binary_einsum!(rule, a, b, out, true, false) ≈ loop_einsum(code, (a, b), size_dict)
                     else
                         @test einsum(code, (a, b), size_dict) ≈ loop_einsum(code, (a, b), size_dict)

--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -78,9 +78,9 @@ end
 
 @testset "get output array" begin
     xs = (randn(4,4), randn(3))
-    @test OMEinsum.get_output_array(xs, (5, 5)) isa Array{Float64}
+    @test OMEinsum.get_output_array(xs, (5, 5), false) isa Array{Float64}
     xs = (randn(4,4), randn(ComplexF64, 3))
-    @test OMEinsum.get_output_array(xs, (5, 5)) isa Array{ComplexF64}
+    @test OMEinsum.get_output_array(xs, (5, 5), false) isa Array{ComplexF64}
 end
 
 @testset "tensor order check" begin


### PR DESCRIPTION
Currently the default is `zeors(T, size...)`, which leads to a huge overhead especially on GPU.

For real numbers:
```julia
julia> using CUDA, BenchmarkTools

julia> @btime CUDA.zeros(Float32, $(fill(2, 20))...);
  9.348 μs (23 allocations: 1.30 KiB)

julia> @btime CuArray{Float32}(undef, $(fill(2, 20))...);
  2.128 μs (5 allocations: 352 bytes)
```

For tropical numbers
```julia
julia> using TropicalNumbers

julia> @btime CUDA.zeros(TropicalF32, $(fill(2, 20))...);
  17.122 μs (106 allocations: 9.69 KiB)

julia> @btime CuArray{TropicalF32}(undef, $(fill(2, 20))...);
  2.163 μs (5 allocations: 352 bytes)
```