### PR TITLE
Fix array initialization in slice einsum

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OMEinsum"
 uuid = "ebe7aa44-baf0-506c-a96f-8464559b3922"
 authors = ["Andreas Peter <andreas.peter.ch@gmail.com>"]
-version = "0.8.7"
+version = "0.8.8"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/slicing.jl
+++ b/src/slicing.jl
@@ -123,7 +123,8 @@ end
 function einsum(se::SlicedEinsum, @nospecialize(xs::NTuple{N,AbstractArray} where N), size_dict::Dict)
     length(se.slicing) == 0 && return einsum(se.eins, xs, size_dict)
     it = SliceIterator(se, size_dict)
-    res = get_output_array(xs, getindex.(Ref(size_dict), it.iyv), false)
+    # Note: the output array must be initialized to 0!
+    res = get_output_array(xs, getindex.(Ref(size_dict), it.iyv), true)
     eins_sliced = drop_slicedim(se.eins, se.slicing)
     for slicemap in it  # `slicemap` is a Dict storing a mapping from sliced_labels to the current slice index
         # NOTE: @debug will break Zygote

--- a/test/slicing.jl
+++ b/test/slicing.jl
@@ -20,11 +20,13 @@ end
     @test getixsv(se) == [['i','j'],['j','k'],['k','l'],['l','m']]
     @test getiyv(se) == ['i','m']
     @test label_elimination_order(se) == ['j','l', 'k']
-    expected = se.eins(xs...)
-    @test se(xs...) ≈ expected
-    y = similar(se(xs...))
-    @test einsum!(se, xs, y, true, false, size_info) ≈ expected
-    @test y ≈ expected
+    for i=1:50
+        expected = se.eins(xs...)
+        @test se(xs...) ≈ expected
+        y = similar(se(xs...))
+        @test einsum!(se, xs, y, true, false, size_info) ≈ expected
+        @test y ≈ expected
+    end
     @test uniquelabels(se) == ['i', 'j', 'k', 'l', 'm']
     @test uniformsize(se, 2) == Dict(zip(['i', 'j', 'k', 'l', 'm'], ones(Int, 5).*2))
 end


### PR DESCRIPTION
@ArrogantGao When using an uninitialized array, e.g. with similar or undef, you will get correct answer in most of the time, since most uninitialized memory have close to 0 values. Once we encounter a nonzero value, it usually takes more than half a day to figure out the bug (check: https://github.com/QuantumBFS/Yao.jl/pull/546).

I have enforced the tests by repeating.