### PR TITLE
Switch GPU extension logging to debug

### DIFF
--- a/ext/AMDGPUExt.jl
+++ b/ext/AMDGPUExt.jl
@@ -141,4 +141,6 @@ function einsum(neinsum::NestedEinsum, @nospecialize(xs::NTuple{N,ROCArrayTypes}
     return res
 end
 
+@debug("OMEinsum loaded the AMDGPU module successfully")
+
 end

--- a/ext/AMDGPUExt.jl
+++ b/ext/AMDGPUExt.jl
@@ -141,6 +141,4 @@ function einsum(neinsum::NestedEinsum, @nospecialize(xs::NTuple{N,ROCArrayTypes}
     return res
 end
 
-@info("OMEinsum loaded the AMDGPU module successfully")
-
 end

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -139,4 +139,6 @@ function einsum(neinsum::NestedEinsum, @nospecialize(xs::NTuple{N,CUDAArrayTypes
     return res
 end
 
+@debug("OMEinsum loaded the CUDA module successfully")
+
 end

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -139,6 +139,4 @@ function einsum(neinsum::NestedEinsum, @nospecialize(xs::NTuple{N,CUDAArrayTypes
     return res
 end
 
-@info("OMEinsum loaded the CUDA module successfully")
-
 end


### PR DESCRIPTION
I want to suggest switching from `@info` to `@debug` for logging messages when a GPU extension module is successfully loaded, as `@info` will always result in verbose output after precompilation:
<img width="418" height="55" alt="image" src="https://github.com/user-attachments/assets/036f7910-94c5-4b12-950f-a28a27cfbbf3" />
Just a little annoyance since it gets shown even when OMEinsum isn't a direct dependency.