### PR TITLE
Make `analyze_binary` evaluate mostly at compile-time

### DIFF
--- a/ext/AMDGPUExt.jl
+++ b/ext/AMDGPUExt.jl
@@ -18,9 +18,9 @@ asarray(x::AbstractArray, y::ROCArray) = x
 asscalar(x::ROCArrayTypes) = Array(x)[]
 
 # to avoid returning a ReshapedArray
-OMEinsum.safe_reshape(x::ROCArray, sz) = reshape(x, (sz...,))
-OMEinsum.safe_reshape(x::Adjoint{T,<:ROCArray{T}} where {T}, sz) = reshape(ROCArray(x), (sz...,))
-OMEinsum.safe_reshape(x::Transpose{T,<:ROCArray{T}} where {T}, sz) = reshape(ROCArray(x), (sz...,))
+OMEinsum.safe_reshape(x::ROCArray, sz) = reshape(x, sz)
+OMEinsum.safe_reshape(x::Adjoint{T,<:ROCArray{T}} where {T}, sz) = reshape(ROCArray(x), sz)
+OMEinsum.safe_reshape(x::Transpose{T,<:ROCArray{T}} where {T}, sz) = reshape(ROCArray(x), sz)
 
 Base.Array(x::Base.ReshapedArray{T,0,<:ROCArray}) where {T} = Array(x.parent)
 

--- a/ext/CUDAExt.jl
+++ b/ext/CUDAExt.jl
@@ -18,9 +18,9 @@ asarray(x::AbstractArray, y::CuArray) = x
 asscalar(x::CUDAArrayTypes) = Array(x)[]
 
 # to avoid returning a ReshapedArray
-OMEinsum.safe_reshape(x::CuArray, sz) = reshape(x, (sz...,))
-OMEinsum.safe_reshape(x::Adjoint{T, <:CuArray{T}} where T, sz) = reshape(CuArray(x), (sz...,))
-OMEinsum.safe_reshape(x::Transpose{T, <:CuArray{T}} where T, sz) = reshape(CuArray(x), (sz...,))
+OMEinsum.safe_reshape(x::CuArray, sz) = reshape(x, sz)
+OMEinsum.safe_reshape(x::Adjoint{T, <:CuArray{T}} where T, sz) = reshape(CuArray(x), sz)
+OMEinsum.safe_reshape(x::Transpose{T, <:CuArray{T}} where T, sz) = reshape(CuArray(x), sz)
 
 Base.Array(x::Base.ReshapedArray{T,0,<:CuArray}) where T = Array(x.parent)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -105,6 +105,10 @@ allunique(ix) = all(i -> count(==(i), ix) == 1, ix)
 _unique(::Type{T}, x::NTuple{N,T}) where {N,T} = unique!(collect(T, x))
 _unique(::Type{T}, x::Vector{T}) where {T} = unique(x)
 
+# Similar to Base.unique, except returns a Tuple instead of a Vector{T}
+# and eligible for evaluation at compile-time
+Base.@assume_effects :foldable _unique(items::Tuple{Vararg{T}}) where T = (Base.unique(items)...,)
+
 function align_eltypes(xs::AbstractArray...)
     T = promote_type(eltype.(xs)...)
     return map(x -> eltype(x) == T ? x : T.(x), xs)

--- a/test/binaryrules.jl
+++ b/test/binaryrules.jl
@@ -4,15 +4,15 @@ using Polynomials: Polynomial
 
 @testset "analyse binary" begin
     size_dict = Dict(1=>1, 2=>2, 3=>3, 4=>4, 6=>6, 7=>7, 8=>8)
-    c1, c2, cy, s1, s2, s3, is, js, ys = OMEinsum.analyze_binary([1,2,3,4,8], [2,6,6,8,4,2], [7,2,1,2,2,6], size_dict)
-    @test c1 == [1,4,8,2]
-    @test c2 == [4,8,6,2]
-    @test cy == [1,6,2]
-    @test s1 == [1,32,2]
-    @test s2 == [32,6,2]
-    @test is == ['i', 'j', 'l']
-    @test js == ['j', 'k', 'l']
-    @test ys == ['i', 'k', 'l']
+    c1, c2, cy, s1, s2, s3, is, js, ys = OMEinsum.analyze_binary(Val((1,2,3,4,8)), Val((2,6,6,8,4,2)), Val((7,2,1,2,2,6)), size_dict)
+    @test c1 == (1,4,8,2)
+    @test c2 == (4,8,6,2)
+    @test cy == (1,6,2)
+    @test s1 == (1,32,2)
+    @test s2 == (32,6,2)
+    @test is == ('i', 'j', 'l')
+    @test js == ('j', 'k', 'l')
+    @test ys == ('i', 'k', 'l')
 end
 
 @testset "binary rules" begin


### PR DESCRIPTION
This tweaks the implementation of `analyze_binary` to take in the dimension indices via `Val`. This allows most of the function to be computed at compile-time, which has a small but positive impact on small matrix reductions:
```julia
julia> @btime code(a,b) setup=(code = ein"i,i->"; a = rand(10); b = rand(10))
  810.314 ns (32 allocations: 1.14 KiB)
  # w/o change: 1.169 μs (58 allocations: 2.20 KiB)
```

This is the first in a series of changes I'm working on to allow `EinCode` to be more statically inferred.

The main advantages of improved inference are (1) this reduces the overhead for small reductions, and (2) pre-compilation will work better, so that user code relying on OMEinsum.jl has to JIT less code at run-time.

This is likely to increase some of the compile-time overhead, in exchange for improved run-time performance. Please let me know if there are any benchmarks / test cases I should keep an eye on to keep compile-time low.