### PR TITLE
Fix CacheTree rrule

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OMEinsum"
 uuid = "ebe7aa44-baf0-506c-a96f-8464559b3922"
 authors = ["Andreas Peter <andreas.peter.ch@gmail.com>"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -71,7 +71,7 @@ macro echo(var)
     esc(:($var = $echo($var; tag="$($name)")))
 end
 
-function ChainRulesCore.rrule(::typeof(CacheTree), content::AbstractArray{T}, siblings) where T
+function ChainRulesCore.rrule(::Type{CacheTree}, content::AbstractArray{T}, siblings) where T
     y = CacheTree(content, siblings)
     function cachetree_pullback(dy)
         dy = unthunk(dy)


### PR DESCRIPTION
Since CacheTree is a type with methods (and a type parameter), `typeof(CacheTree)` yields `UnionAll`, leading to type piracy when it's used for dispatch. For the rrule, `Type{CacheTree}` should be used instead.

I also took the liberty of bumping the patch.

Closes #192 