### PR TITLE
add `-=` operation to `@ein!` inplace macro

### DIFF
--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -262,6 +262,18 @@ end
     @ein! c[i,k] += a[i,j] * b[j,k]
     @test a * b ≈ t
     @test cc + a * b ≈ c
+
+    c = randn(2,2)
+    cc = copy(c)
+    @ein! c[i,k] -= a[i,j] * b[j,k]
+    @test cc - (a * b) ≈ c
+
+    # chaining
+    c = randn(2,2)
+    cc = copy(c)
+    @ein! c[i,k] += a[i,j] * b[j,k]
+    @ein! c[i,k] -= a[i,j] * b[j,k]
+    @test cc ≈ c
 end
 
 @testset "argument checks" begin

--- a/test/einsum.jl
+++ b/test/einsum.jl
@@ -274,6 +274,16 @@ end
     @ein! c[i,k] += a[i,j] * b[j,k]
     @ein! c[i,k] -= a[i,j] * b[j,k]
     @test cc ≈ c
+
+    # tensor contraction
+    a = randn(2,3,4)
+    b = randn(3,5)
+    c = zeros(2,4,5)
+    @ein! c[i,k,l] += a[i,j,k] * b[j,l]
+    @test c ≈ ein"ijk,jl->ikl"(a,b)
+
+    # error
+    @test_throws ArgumentError OMEinsum._ein_macro!(:((a[i] = b[i])))
 end
 
 @testset "argument checks" begin


### PR DESCRIPTION
following #163 .
This is a bit non-trivial and helpful since `@ein! A[i,k] += -B[i,j] * C[j,k] ` would error.
From the code implementation this shall not bring any regression, but I'm happy to add some benchmark upon request.