### PR TITLE
Implement cuTENSOR backend

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "OMEinsum"
 uuid = "ebe7aa44-baf0-506c-a96f-8464559b3922"
-authors = ["Andreas Peter <andreas.peter.ch@gmail.com>"]
 version = "0.9.2"
+authors = ["Andreas Peter <andreas.peter.ch@gmail.com>"]
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -17,10 +17,12 @@ TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 [weakdeps]
 AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+cuTENSOR = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"
 
 [extensions]
 AMDGPUExt = "AMDGPU"
 CUDAExt = "CUDA"
+CuTENSORExt = "cuTENSOR"
 
 [compat]
 AMDGPU = "0.8"
@@ -32,6 +34,7 @@ Combinatorics = "1.0"
 MacroTools = "0.5"
 OMEinsumContractionOrders = "1.1"
 TupleTools = "1.2, 1.3"
+cuTENSOR = "2"
 julia = "1"
 
 [extras]
@@ -47,6 +50,7 @@ SymEngine = "123dc426-2d89-5057-bbad-38513e3affd8"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TropicalNumbers = "b3a74e9c-7526-4576-a4eb-79c0d4c32334"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+cuTENSOR = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"
 
 [targets]
-test = ["Test", "CUDA", "Documenter", "LinearAlgebra", "LuxorGraphPlot", "ProgressMeter", "SymEngine", "Random", "Zygote", "DoubleFloats", "TropicalNumbers", "ForwardDiff", "Polynomials"]
+test = ["Test", "CUDA", "cuTENSOR", "Documenter", "LinearAlgebra", "LuxorGraphPlot", "ProgressMeter", "SymEngine", "Random", "Zygote", "DoubleFloats", "TropicalNumbers", "ForwardDiff", "Polynomials"]

--- a/README.md
+++ b/README.md
@@ -115,6 +115,39 @@ julia> Zl = ein"is, oij, js -> os"(x, W, y);
 └ @ OMEinsum ~/.julia/dev/OMEinsum/src/loop_einsum.jl:26
 ```
 
+## GPU Acceleration
+
+OMEinsum supports CUDA GPU acceleration with two backends:
+
+| Backend | Library | Best For |
+|---------|---------|----------|
+| `DefaultBackend()` | CUBLAS | Matrix-like contractions |
+| `CuTensorBackend()` | cuTENSOR | General tensor contractions |
+
+```julia
+using CUDA
+using OMEinsum
+
+A = CUDA.rand(Float32, 100, 200)
+B = CUDA.rand(Float32, 200, 300)
+
+# Default backend (CUBLAS) - good for matrix-like operations
+C = ein"ij,jk->ik"(A, B)
+```
+
+For better performance on non-GEMM patterns (tensor networks, etc.), use the cuTENSOR backend:
+
+```julia
+using CUDA
+using cuTENSOR  # Pkg.add("cuTENSOR") - loads the CuTENSORExt extension
+using OMEinsum
+
+set_einsum_backend!(CuTensorBackend())
+C = ein"ijk,jkl->il"(CUDA.rand(Float32, 64, 64, 64), CUDA.rand(Float32, 64, 64, 64))
+```
+
+The cuTENSOR backend provides native tensor contraction without reshape/permute overhead. See the [CUDA documentation](https://under-Peter.github.io/OMEinsum.jl/dev/cuda/) for details.
+
 ## Comparison with other packages
 Similar packages include:
 - [TensorOperations.jl](https://github.com/Jutho/TensorOperations.jl) and [TensorKit.jl](https://github.com/Jutho/TensorKit.jl)

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 OMEinsum = "ebe7aa44-baf0-506c-a96f-8464559b3922"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+cuTENSOR = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"

--- a/benchmark/cutensor_benchmark.jl
+++ b/benchmark/cutensor_benchmark.jl
@@ -1,0 +1,180 @@
+using OMEinsum
+using cuTENSOR, cuTENSOR.CUDA
+using BenchmarkTools
+using Printf
+
+# Benchmark configuration
+BenchmarkTools.DEFAULT_PARAMETERS.samples = 100
+BenchmarkTools.DEFAULT_PARAMETERS.seconds = 5
+
+"""
+Run benchmark for a specific einsum code and tensor sizes.
+"""
+function benchmark_einsum(code, sizes, T::Type; warmup=true)
+    # Create input tensors
+    xs = Tuple(CUDA.rand(T, s...) for s in sizes)
+    
+    results = Dict{String, Any}()
+    
+    # Warmup
+    if warmup
+        code(xs...)
+        CUDA.synchronize()
+    end
+    
+    # DefaultBackend (CUBLAS)
+    set_einsum_backend!(DefaultBackend())
+    CUDA.synchronize()
+    
+    default_bench = @benchmark begin
+        $code($xs...)
+        CUDA.synchronize()
+    end
+    results["default"] = default_bench
+    
+    # CuTensorBackend
+    set_einsum_backend!(CuTensorBackend())
+    CUDA.synchronize()
+    
+    cutensor_bench = @benchmark begin
+        $code($xs...)
+        CUDA.synchronize()
+    end
+    results["cutensor"] = cutensor_bench
+
+    # Reset to default
+    set_einsum_backend!(DefaultBackend())
+
+    return results
+end
+
+"""
+Format benchmark results for display.
+"""
+function format_result(bench)
+    med = median(bench)
+    return @sprintf("%.3f ms (±%.3f)", med.time/1e6, std(bench.times)/1e6)
+end
+
+"""
+Print benchmark comparison table.
+"""
+function print_comparison(name, results)
+    default_med = median(results["default"]).time
+    
+    print(@sprintf("%-40s", name))
+    print(@sprintf(" | %-20s", format_result(results["default"])))
+    
+    if haskey(results, "cutensor")
+        cutensor_med = median(results["cutensor"]).time
+        speedup = default_med / cutensor_med
+        print(@sprintf(" | %-20s", format_result(results["cutensor"])))
+        print(@sprintf(" | %.2fx", speedup))
+    else
+        print(" | N/A                  | N/A")
+    end
+    println()
+end
+
+# ============================================================================
+# Benchmark Suite
+# ============================================================================
+
+function run_benchmarks()
+    println("=" ^ 100)
+    println("cuTENSOR vs CUBLAS Benchmark")
+    println("=" ^ 100)
+    println()
+    
+    # GPU Info
+    println("GPU: ", CUDA.name(CUDA.device()))
+    println("CUDA: ", CUDA.runtime_version())
+    println("cuTENSOR: ", cuTENSOR.version())
+    println()
+    
+    for T in [Float32, Float64]
+        println("-" ^ 100)
+        println("Data Type: $T")
+        println("-" ^ 100)
+        println(@sprintf("%-40s | %-20s | %-20s | %s", "Operation", "CUBLAS", "cuTENSOR", "Speedup"))
+        println("-" ^ 100)
+        
+        # 1. Matrix multiplication (GEMM-like)
+        for n in [128, 256, 512, 1024, 2048]
+            name = "matmul ($n×$n)"
+            results = benchmark_einsum(ein"ij,jk->ik", [(n, n), (n, n)], T)
+            print_comparison(name, results)
+        end
+        println()
+        
+        # 2. Rectangular matrix multiplication
+        results = benchmark_einsum(ein"ij,jk->ik", [(512, 1024), (1024, 768)], T)
+        print_comparison("matmul (512×1024, 1024×768)", results)
+        println()
+        
+        # 3. Batched matrix multiplication
+        for (m, n, k, b) in [(64, 64, 64, 32), (128, 128, 128, 16), (256, 256, 256, 8)]
+            name = "batched_matmul ($m×$n×$k, batch=$b)"
+            results = benchmark_einsum(ein"ijl,jkl->ikl", [(m, n, b), (n, k, b)], T)
+            print_comparison(name, results)
+        end
+        println()
+        
+        # 4. Tensor contraction (non-GEMM patterns)
+        # These are where cuTENSOR should shine vs CUBLAS (which needs reshape/permute)
+        
+        # 4a. ijk,jkl->il (contract middle two indices)
+        for d in [16, 32, 64]
+            name = "contract ijk,jkl->il ($(d)³)"
+            results = benchmark_einsum(ein"ijk,jkl->il", [(d, d, d), (d, d, d)], T)
+            print_comparison(name, results)
+        end
+        println()
+        
+        # 4b. ijkl,klmn->ijmn (contract k,l)
+        for d in [8, 16, 24]
+            name = "4D contract ijkl,klmn->ijmn ($d⁴)"
+            results = benchmark_einsum(ein"ijkl,klmn->ijmn", [(d, d, d, d), (d, d, d, d)], T)
+            print_comparison(name, results)
+        end
+        println()
+        
+        # 4c. Trace-like contraction: ij,ji->
+        for n in [256, 512, 1024, 2048]
+            name = "trace ij,ji-> ($n×$n)"
+            results = benchmark_einsum(ein"ij,ji->", [(n, n), (n, n)], T)
+            print_comparison(name, results)
+        end
+        println()
+        
+        # 4d. Outer product: i,j->ij
+        for n in [1024, 2048, 4096]
+            name = "outer i,j->ij ($n)"
+            results = benchmark_einsum(ein"i,j->ij", [(n,), (n,)], T)
+            print_comparison(name, results)
+        end
+        println()
+        
+        # 5. More complex patterns (tensor network style)
+        # 5a. Typical MPS-style contraction
+        D, d = 64, 4  # bond dimension, physical dimension
+        name = "MPS-style aib,bjc->aijc (D=$D, d=$d)"
+        results = benchmark_einsum(ein"aib,bjc->aijc", [(D, d, D), (D, d, D)], T)
+        print_comparison(name, results)
+        
+        # 5b. PEPS-style contraction
+        D = 16
+        name = "PEPS-style ijab,jkbc->ikac (D=$D)"
+        results = benchmark_einsum(ein"ijab,jkbc->ikac", [(D, D, D, D), (D, D, D, D)], T)
+        print_comparison(name, results)
+        
+        println()
+    end
+    
+    println("=" ^ 100)
+    println("Benchmark complete!")
+end
+
+# Run benchmarks
+run_benchmarks()
+

--- a/docs/src/basic.md
+++ b/docs/src/basic.md
@@ -69,3 +69,23 @@ ein"ij,->ij"(A, s)  # element-wise multiplication by a scalar.
 optein"ai,aj,ak->ijk"(A, A, B)  # star contraction.
 optein"ia,ajb,bkc,cld,dm->ijklm"(A, T1, T2, T1, A)  # tensor train contraction.
 ```
+
+## Computation Backends
+
+OMEinsum supports multiple backends for tensor contractions. The backend determines how the underlying computation is performed.
+
+### Available Backends
+
+| Backend | Description | Best For |
+|---------|-------------|----------|
+| `DefaultBackend()` | BLAS/CUBLAS via reshape/permute | General use, matrix operations |
+| `CuTensorBackend()` | NVIDIA cuTENSOR | GPU tensor network contractions |
+
+### Changing Backends
+
+```@repl tensor
+get_einsum_backend()  # check current backend
+set_einsum_backend!(DefaultBackend())  # set to default
+```
+
+For GPU acceleration with cuTENSOR, see [CUDA Acceleration](@ref).

--- a/docs/src/cuda.md
+++ b/docs/src/cuda.md
@@ -1,6 +1,8 @@
 # CUDA Acceleration
 
-By uploading your data to the GPU, you can accelerate the computation of your model.
+OMEinsum supports GPU acceleration through CUDA.jl. By uploading your data to the GPU, you can significantly accelerate tensor contractions.
+
+## Basic CUDA Usage
 
 ```julia repl
 julia> using CUDA, OMEinsum
@@ -41,11 +43,212 @@ julia> @btime optcode($A, $B, $C, $D)  # the contraction on CPU
 
 The contraction on the CPU takes about 6 ms. Now, let's upload the data to the GPU and perform the contraction on the GPU.
 ```julia repl
+julia> cuA, cuB, cuC, cuD = CuArray(A), CuArray(B), CuArray(C), CuArray(D);
+
 julia> @btime CUDA.@sync optcode($cuA, $cuB, $cuC, $cuD)  # the contraction on GPU
   243.888 μs (763 allocations: 28.56 KiB)
 0-dimensional CuArray{Float64, 0, CUDA.DeviceMemory}:
 1.4984046443610939e10
 ```
+
+## GPU Backends
+
+OMEinsum provides two backends for GPU tensor contractions:
+
+| Backend | Library | Best For |
+|---------|---------|----------|
+| `DefaultBackend()` | CUBLAS | Matrix-like contractions (GEMM patterns) |
+| `CuTensorBackend()` | cuTENSOR | General tensor contractions |
+
+### DefaultBackend (CUBLAS)
+
+The default backend uses NVIDIA's CUBLAS library. It works by:
+1. Analyzing the contraction pattern
+2. Reshaping tensors to fit matrix multiplication (GEMM) format
+3. Calling `CUBLAS.gemm_strided_batched!`
+4. Reshaping the result back
+
+This approach works well for contractions that naturally map to matrix multiplication, such as:
+- `ein"ij,jk->ik"` (matrix multiplication)
+- `ein"ijl,jkl->ikl"` (batched matrix multiplication)
+
+### CuTensorBackend (cuTENSOR)
+
+The cuTENSOR backend uses NVIDIA's cuTENSOR library, which provides **native tensor contraction** without the reshape/permute overhead. This is especially beneficial for:
+
+- **Non-GEMM patterns**: Contractions like `ein"ijk,jkl->il"` that don't naturally fit GEMM
+- **High-dimensional tensors**: Avoids costly permutations
+- **Complex index patterns**: Direct support for arbitrary contraction patterns
+
+## Using the cuTENSOR Backend
+
+### Prerequisites
+
+cuTENSOR requires:
+- NVIDIA GPU with compute capability ≥ 6.0
+- CUDA.jl v5.0 or later
+- cuTENSOR.jl package (install with `Pkg.add("cuTENSOR")`)
+
+### Check Availability
+
+```julia
+using CUDA
+using cuTENSOR  # Must be loaded to enable the cuTENSOR backend
+using OMEinsum
+
+# Check if cuTENSOR is available
+if cuTENSOR.has_cutensor()
+    println("cuTENSOR is available!")
+else
+    println("cuTENSOR is not available")
+end
+```
+
+!!! important "Loading cuTENSOR"
+    cuTENSOR.jl is a **separate package**. You must:
+    1. Install it: `Pkg.add("cuTENSOR")`
+    2. Load it **before** or alongside OMEinsum: `using cuTENSOR`
+    
+    This triggers OMEinsum's `CuTENSORExt` extension, which provides the cuTENSOR backend functionality.
+
+### Enable cuTENSOR Backend
+
+```julia
+using CUDA
+using cuTENSOR  # ← Required! This loads the CuTENSORExt extension
+using OMEinsum
+
+# Set the backend globally
+set_einsum_backend!(CuTensorBackend())
+
+# Now all GPU einsum operations will use cuTENSOR
+A = CUDA.rand(Float32, 100, 200, 300)
+B = CUDA.rand(Float32, 200, 300, 400)
+C = ein"ijk,jkl->il"(A, B)  # Uses cuTENSOR
+
+# Reset to default backend
+set_einsum_backend!(DefaultBackend())
+```
+
+!!! warning "Forgetting to load cuTENSOR"
+    If you set `CuTensorBackend()` without loading cuTENSOR.jl, you'll see:
+    ```
+    ┌ Warning: CuTensorBackend: cuTENSOR.jl not loaded - run `using cuTENSOR` first. Will fall back to CUBLAS.
+    ```
+    The computation will still work (using CUBLAS), but you won't get the cuTENSOR optimization.
+
+### Supported Data Types
+
+The cuTENSOR backend supports BLAS-compatible types:
+- `Float16`, `Float32`, `Float64`
+- `ComplexF16`, `ComplexF32`, `ComplexF64`
+
+For other types (e.g., `Double64`, custom number types), the backend automatically falls back to the loop-based implementation.
+
+### Example: Performance Comparison
+
+```julia
+using CUDA
+using cuTENSOR  # Required for cuTENSOR backend
+using OMEinsum, BenchmarkTools
+
+# Create test tensors (non-GEMM pattern)
+A = CUDA.rand(Float32, 64, 64, 64)
+B = CUDA.rand(Float32, 64, 64, 64)
+
+# Benchmark with DefaultBackend (CUBLAS)
+set_einsum_backend!(DefaultBackend())
+@btime CUDA.@sync ein"ijk,jkl->il"($A, $B)
+# Requires: permute → reshape → GEMM → reshape
+
+# Benchmark with CuTensorBackend
+set_einsum_backend!(CuTensorBackend())
+@btime CUDA.@sync ein"ijk,jkl->il"($A, $B)
+# Direct tensor contraction - no intermediate steps!
+```
+
+### When to Use cuTENSOR
+
+| Use Case | Recommended Backend |
+|----------|-------------------|
+| Matrix multiplication `ij,jk->ik` | Either (similar performance) |
+| Batched matmul `ijl,jkl->ikl` | Either (similar performance) |
+| Tensor contraction `ijk,jkl->il` | **CuTensorBackend** |
+| High-dimensional `ijkl,klmn->ijmn` | **CuTensorBackend** |
+| MPS/PEPS contractions | **CuTensorBackend** |
+| Non-BLAS types (Double64, etc.) | DefaultBackend |
+
+### Best Practices
+
+1. **Use cuTENSOR for tensor networks**: If you're doing MPS, PEPS, or general tensor network contractions, cuTENSOR typically provides better performance.
+
+2. **Profile your workload**: The relative performance depends on tensor sizes and contraction patterns. Use `BenchmarkTools` to measure.
+
+3. **Keep data on GPU**: Minimize CPU-GPU transfers by keeping intermediate results on the GPU.
+
+4. **Batch operations**: When contracting many small tensors, consider batching them together.
+
+```julia
+# Good: Keep data on GPU throughout
+cuA, cuB, cuC = CuArray.((A, B, C))
+result = ein"(ij,jk),kl->il"(cuA, cuB, cuC)
+
+# Avoid: Repeated transfers
+result = ein"ij,jk->ik"(CuArray(A), CuArray(B))  # Transfer every call
+```
+
+## Nested Contractions with cuTENSOR
+
+The cuTENSOR backend works seamlessly with optimized contraction orders:
+
+```julia
+using CUDA, cuTENSOR, OMEinsum
+
+set_einsum_backend!(CuTensorBackend())
+
+# Define a tensor network
+code = ein"ij,jk,kl,lm->im"
+
+# Optimize contraction order
+size_dict = Dict('i'=>100, 'j'=>100, 'k'=>100, 'l'=>100, 'm'=>100)
+optcode = optimize_code(code, size_dict, TreeSA())
+
+# Execute with cuTENSOR (each pairwise contraction uses cuTENSOR)
+A, B, C, D = [CUDA.rand(Float32, 100, 100) for _ in 1:4]
+result = optcode(A, B, C, D)
+```
+
+## Troubleshooting
+
+### cuTENSOR not detected
+
+If `has_cutensor()` returns `false`:
+
+1. **Check CUDA.jl version**: Ensure you have CUDA.jl v5.0+
+   ```julia
+   using Pkg
+   Pkg.status("CUDA")
+   ```
+
+2. **Check GPU compatibility**: cuTENSOR requires compute capability ≥ 6.0
+   ```julia
+   using CUDA
+   CUDA.capability(CUDA.device())
+   ```
+
+3. **Reinstall CUDA artifacts**:
+   ```julia
+   using CUDA
+   CUDA.versioninfo()  # Check if cuTENSOR is listed
+   ```
+
+### Performance not as expected
+
+1. **Ensure synchronization**: Use `CUDA.@sync` when benchmarking
+2. **Check tensor sizes**: cuTENSOR has more overhead for very small tensors
+3. **Verify backend is active**: Check `get_einsum_backend()`
+
+## Video Tutorial
 
 To learn more about using GPU and autodiff, please check out the following asciinema video.
 [![asciicast](https://asciinema.org/a/wE4CtIzWUC3R0GkVV28rVBRFb.svg)](https://asciinema.org/a/wE4CtIzWUC3R0GkVV28rVBRFb)

--- a/ext/CuTENSORExt.jl
+++ b/ext/CuTENSORExt.jl
@@ -1,0 +1,51 @@
+module CuTENSORExt
+
+using OMEinsum: EinsumBackend, DefaultBackend, CuTensorBackend, get_einsum_backend, CuTensorSupportedTypes, _CUTENSOR_AVAILABLE, _CUTENSOR_EINSUM_IMPL
+import OMEinsum
+using cuTENSOR
+using cuTENSOR.CUDA
+
+# Set flags at module initialization (runtime), not precompilation time
+function __init__()
+    _CUTENSOR_AVAILABLE[] = true
+    _CUTENSOR_EINSUM_IMPL[] = cutensor_einsum!
+end
+
+"""
+    cutensor_einsum!(ixs, iy, xs::NTuple{2,CuArray{T}}, y::CuArray{T}, sx, sy, size_dict) where T
+
+Perform binary tensor contraction using cuTENSOR.jl.
+This provides native tensor contraction without reshape/permute overhead.
+"""
+function cutensor_einsum!(
+    ixs, iy,
+    xs::NTuple{2,CuArray{T}}, y::CuArray{T},
+    sx, sy, size_dict
+) where {T<:CuTensorSupportedTypes}
+    if length(ixs) != 2
+        error("cuTENSOR backend only supports binary contractions")
+    end
+    
+    A, B = xs
+    ix1, ix2 = ixs[1], ixs[2]
+    
+    # Convert labels to vectors (cuTENSOR accepts Char or Integer indices)
+    modes_A = collect(ix1)
+    modes_B = collect(ix2)
+    modes_C = collect(iy)
+    
+    # cuTENSOR.contract!(α, A, Ainds, opA, B, Binds, opB, β, C, Cinds, opC, opOut)
+    cuTENSOR.contract!(
+        T(sx), A, modes_A, cuTENSOR.OP_IDENTITY,
+        B, modes_B, cuTENSOR.OP_IDENTITY,
+        T(sy), y, modes_C, cuTENSOR.OP_IDENTITY,
+        cuTENSOR.OP_IDENTITY
+    )
+    
+    return y
+end
+
+@debug "OMEinsum: cuTENSOR extension loaded"
+
+end
+

--- a/src/OMEinsum.jl
+++ b/src/OMEinsum.jl
@@ -15,6 +15,9 @@ export flop
 export loop_einsum, loop_einsum!, allow_loops
 export asarray, asscalar
 export cost_and_gradient
+# backend exports
+export EinsumBackend, DefaultBackend, CuTensorBackend
+export set_einsum_backend!, get_einsum_backend
 
 # re-export the functions in OMEinsumContractionOrders
 export CodeOptimizer, CodeSimplifier,
@@ -32,6 +35,7 @@ export CodeOptimizer, CodeSimplifier,
     # visualization
     viz_eins, viz_contraction
 
+include("backends.jl")
 include("Core.jl")
 include("loop_einsum.jl")
 include("utils.jl")

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -1,0 +1,237 @@
+"""
+    EinsumBackend
+
+Abstract type for einsum computation backends.
+
+OMEinsum supports multiple backends for tensor contractions, allowing users
+to choose the most appropriate implementation for their hardware and use case.
+
+## Available Backends
+- [`DefaultBackend`](@ref): Uses BLAS/CUBLAS with reshape/permute operations
+- [`CuTensorBackend`](@ref): Uses NVIDIA cuTENSOR for native tensor contractions
+
+## Usage
+```julia
+# Check current backend
+get_einsum_backend()
+
+# Change backend globally
+set_einsum_backend!(CuTensorBackend())
+```
+
+See also: [`set_einsum_backend!`](@ref), [`get_einsum_backend`](@ref)
+"""
+abstract type EinsumBackend end
+
+"""
+    DefaultBackend <: EinsumBackend
+
+Default backend using BLAS/CUBLAS for tensor contractions.
+
+This backend reduces tensor contractions to matrix multiplications (GEMM) by:
+1. Analyzing the contraction pattern to identify inner/outer/batch indices
+2. Permuting tensors to canonical GEMM form if needed
+3. Reshaping tensors to 2D/3D matrices
+4. Calling optimized BLAS routines (`gemm!`, `gemm_strided_batched!`)
+5. Reshaping and permuting the result back
+
+## Pros
+- Highly optimized for matrix-like contractions
+- Works with any array type that supports `mul!`
+- No additional library dependencies
+
+## Cons
+- Overhead from permute/reshape for non-GEMM patterns
+- May allocate intermediate arrays
+
+## Example
+```julia
+set_einsum_backend!(DefaultBackend())
+ein"ij,jk->ik"(A, B)  # Uses BLAS gemm
+```
+"""
+struct DefaultBackend <: EinsumBackend end
+
+"""
+    CuTensorBackend <: EinsumBackend
+
+Backend using NVIDIA cuTENSOR library for native tensor contractions on GPU.
+
+This backend calls cuTENSOR's `contraction!` function directly, which:
+- Handles arbitrary tensor contraction patterns natively
+- Eliminates reshape/permute overhead
+- Optimizes memory access patterns internally
+
+## Requirements
+- NVIDIA GPU with compute capability ≥ 6.0
+- CUDA.jl v5.0 or later with cuTENSOR support
+
+## Supported Types
+- `Float16`, `Float32`, `Float64`
+- `ComplexF16`, `ComplexF32`, `ComplexF64`
+
+For unsupported types, automatically falls back to `DefaultBackend`.
+
+## Pros
+- No intermediate allocations for non-GEMM patterns
+- Better performance for tensor network contractions
+- Native support for arbitrary index patterns
+
+## Cons
+- Only available on NVIDIA GPUs with cuTENSOR
+- Slightly higher overhead for simple GEMM patterns
+- Limited to BLAS-compatible numeric types
+
+## Example
+```julia
+using CUDA, OMEinsum
+
+# Check if cuTENSOR is available
+ext = Base.get_extension(OMEinsum, :CUDAExt)
+ext.has_cutensor()  # true if available
+
+# Enable cuTENSOR backend
+set_einsum_backend!(CuTensorBackend())
+
+# Tensor contraction (benefits most from cuTENSOR)
+A = CUDA.rand(Float32, 64, 64, 64)
+B = CUDA.rand(Float32, 64, 64, 64)
+C = ein"ijk,jkl->il"(A, B)  # Direct cuTENSOR call, no reshape needed
+```
+
+## When to Use
+- Tensor network contractions (MPS, PEPS, etc.)
+- High-dimensional tensor operations
+- Contractions with complex index patterns like `ein"ijkl,klmn->ijmn"`
+
+See also: [`DefaultBackend`](@ref), [`set_einsum_backend!`](@ref)
+"""
+struct CuTensorBackend <: EinsumBackend end
+
+# Global backend configuration
+const EINSUM_BACKEND = Ref{EinsumBackend}(DefaultBackend())
+
+"""
+    set_einsum_backend!(backend::EinsumBackend) -> EinsumBackend
+
+Set the global backend for einsum operations.
+
+!!! note
+    This sets a global state. For thread-safe usage in concurrent code,
+    consider using the same backend throughout or synchronizing access.
+
+## Arguments
+- `backend::EinsumBackend`: The backend to use.
+  - `DefaultBackend()`: Use BLAS/CUBLAS (default)
+  - `CuTensorBackend()`: Use cuTENSOR for GPU contractions
+
+## Returns
+The backend that was set.
+
+## Example
+```julia
+using OMEinsum, CUDA
+
+# Check current backend
+get_einsum_backend()  # DefaultBackend()
+
+# Switch to cuTENSOR
+set_einsum_backend!(CuTensorBackend())
+
+# Perform contractions with cuTENSOR
+A = CUDA.rand(Float32, 100, 200)
+B = CUDA.rand(Float32, 200, 300)
+C = ein"ij,jk->ik"(A, B)
+
+# Reset to default
+set_einsum_backend!(DefaultBackend())
+```
+
+## Performance Comparison
+```julia
+using BenchmarkTools
+
+A = CUDA.rand(Float32, 64, 64, 64)
+B = CUDA.rand(Float32, 64, 64, 64)
+
+# DefaultBackend: requires permute + reshape + GEMM + reshape
+set_einsum_backend!(DefaultBackend())
+@btime CUDA.@sync ein"ijk,jkl->il"(\$A, \$B)
+
+# CuTensorBackend: direct tensor contraction
+set_einsum_backend!(CuTensorBackend())
+@btime CUDA.@sync ein"ijk,jkl->il"(\$A, \$B)
+```
+
+See also: [`get_einsum_backend`](@ref), [`EinsumBackend`](@ref)
+"""
+function set_einsum_backend!(backend::EinsumBackend)
+    EINSUM_BACKEND[] = backend
+    return backend
+end
+
+# Hook for extensions to check backend availability - returns (available::Bool, message::String)
+check_backend_availability(::EinsumBackend) = (true, "")
+
+# Registry for backend availability (used to avoid method overwriting during precompilation)
+const _CUTENSOR_AVAILABLE = Ref{Bool}(false)
+
+# Function reference for cuTENSOR einsum - set by CuTENSORExt when loaded
+const _CUTENSOR_EINSUM_IMPL = Ref{Any}(nothing)
+
+function _cutensor_einsum!(ixs, iy, xs, y, sx, sy, size_dict)
+    impl = _CUTENSOR_EINSUM_IMPL[]
+    if impl === nothing
+        error("cuTENSOR extension not loaded. Please run `using cuTENSOR`.")
+    end
+    return impl(ixs, iy, xs, y, sx, sy, size_dict)
+end
+
+function check_backend_availability(::CuTensorBackend)
+    if _CUTENSOR_AVAILABLE[]
+        return (true, "")
+    end
+    return (false, "cuTENSOR.jl not loaded - run `using cuTENSOR` first")
+end
+
+function set_einsum_backend!(backend::CuTensorBackend)
+    available, msg = check_backend_availability(backend)
+    available || @warn "CuTensorBackend: $msg. Will fall back to CUBLAS."
+    EINSUM_BACKEND[] = backend
+end
+
+"""
+    get_einsum_backend() -> EinsumBackend
+
+Get the current global einsum backend.
+
+## Returns
+The currently active `EinsumBackend` instance.
+
+## Example
+```julia
+backend = get_einsum_backend()
+if backend isa CuTensorBackend
+    println("Using cuTENSOR")
+else
+    println("Using default BLAS/CUBLAS")
+end
+```
+
+See also: [`set_einsum_backend!`](@ref), [`EinsumBackend`](@ref)
+"""
+get_einsum_backend() = EINSUM_BACKEND[]
+
+"""
+    CuTensorSupportedTypes
+
+Union of numeric types supported by the cuTENSOR backend.
+
+```julia
+CuTensorSupportedTypes = Union{Float16, Float32, Float64, ComplexF16, ComplexF32, ComplexF64}
+```
+
+Arrays with element types not in this union will automatically fall back to
+the default backend when `CuTensorBackend` is active.
+"""
+const CuTensorSupportedTypes = Union{Float16, Float32, Float64, ComplexF16, ComplexF32, ComplexF64}


### PR DESCRIPTION
Fix #194 

```
==================================================================================================
BENCHMARK SUMMARY
==================================================================================================
Framework       Device                         Backend         Result          Min Time (s)   
--------------------------------------------------------------------------------------------------
OMEinsum        icelake-server                 MKL             0.999994        14.6704        
OMEinsum        NVIDIA A800 80GB PCIe          cublas          0.999992        0.2383         
OMEinsum        NVIDIA A800 80GB PCIe          cutensor        0.999991        0.0572         
pytorch         x86_64                         cpu             0.999994        17.2420        
pytorch         NVIDIA A800 80GB PCIe          cuda            0.999998        0.1069         
==================================================================================================
```

Now is even faster than pytorch (check this benchmark: https://github.com/TensorBFS/TensorNetworkBenchmarks).

## Note
For better performance on non-GEMM patterns (tensor networks, etc.), use the cuTENSOR backend:

```julia
using CUDA
using cuTENSOR  # Pkg.add("cuTENSOR") - loads the CuTENSORExt extension
using OMEinsum

set_einsum_backend!(CuTensorBackend())
C = ein"ijk,jkl->il"(CUDA.rand(Float32, 64, 64, 64), CUDA.rand(Float32, 64, 64, 64))
```

The cuTENSOR backend provides native tensor contraction without reshape/permute overhead. See the [CUDA documentation](https://under-Peter.github.io/OMEinsum.jl/dev/cuda/) for details.