### PR TITLE
Fix parsing greek chars

### DIFF
--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -7,7 +7,7 @@ an `einsum`.
 To control evaluation order, use parentheses - instead of an `EinCode`,
 a `NestedEinsum` is returned which evaluates the expression
 according to parens.
-The valid character ranges for index-labels are `a-z` and `α-ω`.
+Index labels can be any Unicode letter (e.g. `a-z`, `α-ω`, `ϵ`, `ξ`, etc.).
 
 # example
 
@@ -34,7 +34,7 @@ end
 
 function ein(s::AbstractString)
     s = replace(replace(s, "\n" => ""), " "=>"")
-    m = match(r"([\(\)a-z,α-ω]*)->([a-zα-ω]*)", s)
+    m = match(r"^([\(\)\p{L},]*)->(\p{L}*)$", s)
     m === nothing && throw(ArgumentError("invalid einsum specification $s"))
     sixs, siy = m.captures
     if '(' in sixs

--- a/test/interfaces.jl
+++ b/test/interfaces.jl
@@ -15,6 +15,34 @@ using OMEinsum: get_size_dict
     ikl" == ein"ijk,ijk->ikl"
 end
 
+@testset "unicode index labels" begin
+    # basic Greek letters (within α-ω range)
+    ec1 = ein"aζ,ζβ->aβ"
+    @test OMEinsum.getixs(ec1) == (('a', 'ζ'), ('ζ', 'β'))
+    @test OMEinsum.getiy(ec1) == ('a', 'β')
+
+    # Greek letters outside α-ω range (e.g. ϵ = U+03F5)
+    ec2 = ein"abc,ζαfa,ϵβeb,δγdc,def,βγ,ϵζ->δα"
+    @test length(OMEinsum.getixs(ec2)) == 7
+    @test OMEinsum.getixs(ec2)[3] == ('ϵ', 'β', 'e', 'b')
+    @test OMEinsum.getiy(ec2) == ('δ', 'α')
+
+    # correctness: Greek indices contract properly
+    A = rand(3, 3)
+    B = rand(3, 3)
+    @test ein"αβ,βγ->αγ"(A, B) ≈ A * B
+    @test ein"αi,iγ->αγ"(A, B) ≈ A * B
+
+    # nested einsum with Unicode
+    ec3 = ein"(αβ,βγ),γδ->αδ"
+    @test ec3 isa NestedEinsum
+    C = rand(3, 3)
+    @test ec3(A, B, C) ≈ A * B * C
+
+    # invalid characters should error, not silently truncate
+    @test_throws ArgumentError OMEinsum.ein("ab,b1->a1")
+end
+
 @testset "opein" begin
     code = optein"ij,jk,ki->"
     @test code isa NestedEinsum


### PR DESCRIPTION
## Summary
- Fix `@ein_str` silently returning truncated results when Unicode characters outside the `α-ω` (U+03B1–U+03C9) range are used as index labels (e.g. `ϵ` = U+03F5)
- Replace character class `[a-zα-ω]` with `\p{L}` (any Unicode letter) and anchor the regex with `^...$` to prevent silent partial matches

Closes #197

## Details

The regex `r"([\(\)a-z,α-ω]*)->([a-zα-ω]*)"` failed for characters like `ϵ` (Greek Lunate Epsilon Symbol, U+03F5) which falls outside the `α`–`ω` range. Since the regex was unanchored, it would silently match a partial substring instead of throwing an error, leading to wrong results:

```julia
ec = ein"abc,ζαfa,ϵβeb,δγdc,def,βγ,ϵζ->δα"
OMEinsum.getixs(ec)  # (('ζ',),)  — silently wrong, should have 7 input tensors
```

The fix:
1. Uses `\p{L}` (any Unicode letter) instead of `a-z,α-ω` to accept all valid Unicode letters
2. Anchors the regex with `^...$` so invalid input throws `ArgumentError` instead of silently truncating

## Test plan
- [x] Basic Greek letters within α-ω range parse correctly
- [x] Greek letters outside α-ω range (e.g. `ϵ` U+03F5) parse correctly
- [x] Mixed Latin/Greek indices contract correctly
- [x] Nested einsum with Unicode works
- [x] Invalid characters throw `ArgumentError` instead of silent truncation
- [x] Existing test suite passes